### PR TITLE
Fix autoRotate when limiting yaw and several other fixes

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -869,7 +869,16 @@ function zoomOut(amount) {
 
 function setHfov(i) {
     // Keep field of view within bounds
-    config.hfov = Math.max(config.minhfov, Math.min(config.maxhfov, i));
+    if (i < config.minhfov && config.type != 'multires') {
+        config.hfov = config.minhfov;
+    } else if (config.type == 'multires' && i < canvas.width
+        / (config.multiRes.cubeResolution / 90 * 0.9)) {
+        config.hfov = canvas.width / (config.multiRes.cubeResolution / 90 * 0.9);
+    } else if (i > config.maxhfov) {
+        config.hfov = config.maxhfov;
+    } else {
+        config.hfov = i;
+    }
 }
 
 function load() {


### PR DESCRIPTION
As I discussed in my previous issue (mpetroff/pannellum#13), my proposed code broke autoRotate, so I fix that now. The idea behind the fix is that when one limits the yaw, the rotate when reaching minyaw changes direction and then when reaching the maxyaw changes direction again.

Other fixes include:
- **Fix error box behavior when loading next scene** - When one uses WebGL on a full equirectangular panorama if the panorama is too large it gives a WebGL error (and a respective error box in pannellum). This all blocks further tour for example if there are hotspots available. So I made the error box to be cleared (display:none;) every time _load()_ is called,  so the user to be able to load another scene that may be less resource hungry (and thus not giving any error)
- **Fix preview image behavior** Preview image is sized auto. This makes it dependent on its own size and the size of the parent iframe (giving tiled or cropped results when there is inconsistency between the iframe and the image size). I think a size of "100% 100%" is a better choice.
- **Fix multires hfov behavior in fullscreen/wide mode** - I am not good at maths, so I do not know why is all that code separation for multires in _setHfov(i)_, but there is a very strange zooming problem when using a wide iframe(or fullscreen on a wide monitor 1920x1080 and a _cubeResolution_ of 1216 or 1432 maybe other resoliutions too but I have not tested that thouroughly).  The problem is that there are only two levels of zooming and the one is not at all good at 157 deg. Anyway I removed all that code and left only a check for the min and max hfov. It works ok with my two multires panoramas. These are their configs:

```
            "multiRes": {
                "basePath": "img/multires/room2",
                "path": "/%l/%s%y_%x",
                "fallbackPath": "/fallback/%s",
                "extension": "jpg",
                "tileResolution": 512,
                "maxLevel": 3,
                "cubeResolution": 1432
                }

```

```
            "multiRes": {
                "basePath": "img/multires/room2",
                "path": "/%l/%s%y_%x",
                "fallbackPath": "/fallback/%s",
                "extension": "jpg",
                "tileResolution": 512,
                "maxLevel": 3,
                "cubeResolution": 1216
            },
```

I hope you will like the proposed changes.

Thanks :)
