### PR TITLE
[hotspots scene] Fix iOS onclick + hover bug

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -582,6 +582,10 @@ function createHotSpots() {
                         loadScene(hs.sceneId);
                         return false;
                     };
+                    div.ontouchend = function() {
+                        loadScene(hs.sceneId);
+                        return false;
+                    };
                     div.style.cursor = 'pointer';
                     span.style.cursor = 'pointer';
                 }


### PR DESCRIPTION
There is a bug in iOS/Mobile Safari that randomly prevents the _onclick_ event when the clicked element has a _:hover_ css rule (more info here: [Why your click events don't work on Mobile Safari](http://www.shdon.com/blog/2013/06/07/why-your-click-events-don-t-work-on-mobile-safari) ).

In the pannellum case when there is a hotspot connected to a scene, when one uses Mobile Safari (tests run on iPad Air - iOS 7.1.1 and iPhone 5 and 5S with a custom tour and with the original one on pannellum.org) clicking(touching) the hotspot doesn't always work properly. Mostly it does show the title of the scene as a tooltip (done by the css rules) and doesn't load the scene (no matter how you "click"/touch and how many times you do it). The "offending" css rule is:

```
div.tooltip:hover span{
    visibility: visible;
}
```

When you remove the rule, all works ok. But this is not a solution anyway...

So.. this is a proposed easy fix, tested and working ok. It uses the _ontouchend_ event leaving the _onclick_ for the browsers that do not support touch events.
The fix has a small disadvantage - to see the title of the scene one has to touch and hold the hotspot... but on Android the scene title (even when only _onclick_ event is present in the code) is not seen by default anyway (it appears for a very short time after the click event if the connection is fast).

Thanks
