### PR TITLE
Fix undefined error when moving too fast

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -948,7 +948,9 @@ function renderInitCallback() {
             oldRenderer.fadeImg.style.opacity = 0;
             // Remove image
             setTimeout(function() {
-                renderContainer.removeChild(oldRenderer.fadeImg);
+                if(oldRenderer && oldRenderer.fadeImg){
+                    renderContainer.removeChild(oldRenderer.fadeImg);
+                }
                 oldRenderer = undefined;
             }, config.sceneFadeDuration);
         }


### PR DESCRIPTION
If we are switching from one image to another too fast, oldRenderer is undefined at that point. This fix that.