### PR TITLE
Moving from visibility to display due to Chrome bug

### DIFF
--- a/src/css/pannellum.css
+++ b/src/css/pannellum.css
@@ -282,7 +282,7 @@ body {
     position: absolute;
     height: 26px;
     width: 26px;
-    visibility: hidden;
+    display: none;
     cursor: default;
     border-radius: 13px;
     vertical-align: middle;
@@ -300,7 +300,7 @@ body {
 }
 
 div.tooltip span {
-    visibility: hidden;
+    display: none;
     position: absolute;
     border-radius: 3px;
     background-color: rgba(0,0,0,0.7);
@@ -313,7 +313,7 @@ div.tooltip span {
     cursor: default;
 }
 div.tooltip:hover span{
-    visibility: visible;
+    display: block;
 }
 div.tooltip:hover:after {
     content: '';

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1072,9 +1072,9 @@ function renderHotSpots() {
         var z = hsPitchSin * configPitchSin + hsPitchCos * yawCos * configPitchCos;
         if ((hs.yaw <= 90 && hs.yaw > -90 && z <= 0) ||
           ((hs.yaw > 90 || hs.yaw <= -90) && z <= 0)) {
-            hs.div.style.visibility = 'hidden';
+            hs.div.style.display = 'none';
         } else {
-            hs.div.style.visibility = 'visible';
+            hs.div.style.display = 'block';
             // Subpixel rendering doesn't work in Firefox
             // https://bugzilla.mozilla.org/show_bug.cgi?id=739176
             var transform = 'translate(' + (-renderer.canvas.width /


### PR DESCRIPTION
If you animate the hotspot (which is not the default case for pannellum, but which it could be) with an infinite CSS keyFrame animation, `vissibility:hidden` has an error in Chrome, as I described here: http://stackoverflow.com/questions/30167467/css-infinite-animation-after-hidden-is-not-resetted-chrome