### PR TITLE
Fix 'undefined' bug in fallback URLs (in library version)

### DIFF
--- a/src/js/libpannellum.js
+++ b/src/js/libpannellum.js
@@ -95,7 +95,12 @@ function Renderer(container, image, imageType, video) {
             world.className = 'pnlm-world';
             
             // Add images
-            var path = image.basePath + image.fallbackPath;
+            var path;
+            if (image.basePath) {
+                path = image.basePath + image.fallbackPath;
+            } else {
+                path = image.fallbackPath;
+            }
             var sides = ['f', 'r', 'b', 'l', 'u', 'd'];
             var loaded = 0;
             var onLoad = function() {


### PR DESCRIPTION
Fixes a small bug noticed in library version.
basePath isn't checked for fallback tiles, so undefined appear in the URL fallback tile URL if basePath isn't defined.