### PR TITLE
Add support for URL specified firstScene.

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -178,8 +178,11 @@ compass.className = 'pnlm-compass pnlm-controls pnlm-control';
 container.appendChild(compass);
 
 // Load and process configuration
-if (initialConfig.default && initialConfig.default.firstScene) {
-    // Activate first scene if specified
+if (initialConfig.firstScene) {
+    // Activate first scene if specified in URL
+    mergeConfig(initialConfig.firstScene);
+} else if (initialConfig.default && initialConfig.default.firstScene) {
+    // Activate first scene if specified in file
     mergeConfig(initialConfig.default.firstScene);
 } else {
     mergeConfig(null);


### PR DESCRIPTION
This allows references to the standalone viewer to start in the "middle" of a tour. I needed it to provide an table of contents for a tour and I thought others might find it useful. 