### PR TITLE
enable generates.py to take cube faces as input

### DIFF
--- a/utils/multires/generate.py
+++ b/utils/multires/generate.py
@@ -4,17 +4,18 @@
 
 # generate.py - A multires tile set generator for Pannellum
 # Copyright (c) 2014-2015 Matthew Petroff
-# 
+# Copyright (c) 2016 Franck Barbenoire
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,14 +34,17 @@ import math
 from distutils.spawn import find_executable
 import subprocess
 
+# Face order: front, back, up, down, left, right
+faceLetters = ['f', 'b', 'u', 'd', 'l', 'r']
+
 # find external programs
 nona = find_executable('nona')
 
 # Parse input
 parser = argparse.ArgumentParser(description='Generate a Pannellum multires tile set from an full equirectangular panorama.',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('inputFile', metavar='INPUT',
-                    help='full equirectangular panorama to be processed')
+parser.add_argument('input', metavar='INPUT',
+                    help='full equirectangular panorama to be processed or directory containing cube faces')
 parser.add_argument('-o', '--output', dest='output', default='./output',
                     help='output directory')
 parser.add_argument('-s', '--tilesize', dest='tileSize', default=512, type=int,
@@ -56,56 +60,85 @@ parser.add_argument('-n', '--nona', default=nona, required=nona is None,
                     help='location of the nona executable to use')
 args = parser.parse_args()
 
-# Process input image information
-print('Processing input image information...')
-origWidth, origHeight = Image.open(args.inputFile).size
-if float(origWidth) / origHeight != 2:
-    print('Error: the image width is not twice the image height.')
-    print('Input image must be a full, not partial, equirectangular panorama!')
-    sys.exit(1)
-if args.cubeSize != 0:
-    cubeSize = args.cubeSize
-else:
-    cubeSize = 8 * int(origWidth / 3.14159265 / 8)
-levels = int(math.ceil(math.log(float(cubeSize) / args.tileSize, 2))) + 1
-origHeight = str(origHeight)
-origWidth = str(origWidth)
-origFilename = os.path.join(os.getcwd(), args.inputFile)
-extension = '.jpg'
-if args.png:
-    extension = '.png'
-
 # Create output directory
 os.makedirs(args.output)
 
-# Generate PTO file for nona to generate cube faces
-# Face order: front, back, up, down, left, right
-faceLetters = ['f', 'b', 'u', 'd', 'l', 'r']
-text = []
-text.append('p E0 R0 f0 h' + str(cubeSize) + ' n"TIFF_m" u0 v90 w' + str(cubeSize))
-text.append('m g1 i0 m2 p0.00784314')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y0')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y180')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p-90 r0 v360 w' + origWidth + ' y0')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p90 r0 v360 w' + origWidth + ' y0')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y90')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y-90')
-text.append('v')
-text.append('*')
-text = '\n'.join(text)
-with open(os.path.join(args.output, 'cubic.pto'), 'w') as f:
-    f.write(text)
+# Process input image information
+print('Processing input image information...')
+if os.path.isdir(args.input):
+    inputDir = args.input
+    removeFaces = False
+    # check input arguments
+    faces = [f for f in os.listdir(inputDir) if os.path.isfile(os.path.join(args.input, f))]
+    if len(faces) != 6:
+        print('Error: the number of faces is different than 6.')
+        sys.exit(1)
+    cubeSize = -1
+    for f in faces:
+        f = os.path.join(args.input, f)
+        with Image.open(f) as image:
+            w, h = image.size
+            if w != h:
+                print('Error: the face %s is not a square.' % f)
+                sys.exit(1)
+            if cubeSize == -1:
+               cubeSize = w
+            elif w != cubeSize:
+                print("Error: all faces don't have the same size.")
+                sys.exit(1)
+    # sort image names, it is assumed that the first letter is in "fbudlr"
+    faces = sorted(faces, key=lambda f: faceLetters.index(f[0]))
+else:
+    inputDir = args.output
+    removeFaces = True
+    # generates the cube faces from the equirectangular file
+    origWidth, origHeight = Image.open(args.input).size
+    if float(origWidth) / origHeight != 2:
+        print('Error: the image width is not twice the image height.')
+        print('Input image must be a full, not partial, equirectangular panorama!')
+        sys.exit(1)
+    if args.cubeSize != 0:
+        cubeSize = args.cubeSize
+    else:
+        cubeSize = 8 * int(origWidth / 3.14159265 / 8)
 
-# Create cube faces
-print('Generating cube faces...')
-subprocess.check_call([args.nona, '-o', os.path.join(args.output, 'face'), os.path.join(args.output, 'cubic.pto')])
-faces = ['face0000.tif', 'face0001.tif', 'face0002.tif', 'face0003.tif', 'face0004.tif', 'face0005.tif']
+    origHeight = str(origHeight)
+    origWidth = str(origWidth)
+    origFilename = os.path.join(os.getcwd(), args.input)
+
+    # Generate PTO file for nona to generate cube faces
+    text = []
+    text.append('p E0 R0 f0 h' + str(cubeSize) + ' n"TIFF_m" u0 v90 w' + str(cubeSize))
+    text.append('m g1 i0 m2 p0.00784314')
+    text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y0')
+    text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y180')
+    text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p-90 r0 v360 w' + origWidth + ' y0')
+    text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p90 r0 v360 w' + origWidth + ' y0')
+    text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y90')
+    text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y-90')
+    text.append('v')
+    text.append('*')
+    text = '\n'.join(text)
+    with open(os.path.join(args.output, 'cubic.pto'), 'w') as f:
+        f.write(text)
+
+    # Create cube faces
+    print('Generating cube faces...')
+    subprocess.check_call([args.nona, '-o', os.path.join(args.output, 'face'), os.path.join(args.output, 'cubic.pto')])
+    os.remove(os.path.join(args.output, 'cubic.pto'))
+    faces = ['face0000.tif', 'face0001.tif', 'face0002.tif', 'face0003.tif', 'face0004.tif', 'face0005.tif']
+
+levels = int(math.ceil(math.log(float(cubeSize) / args.tileSize, 2))) + 1
+
+extension = '.jpg'
+if args.png:
+    extension = '.png'
 
 # Generate tiles
 print('Generating tiles...')
 for f in range(0, 6):
     size = cubeSize
-    face = Image.open(os.path.join(args.output, faces[f]))
+    face = Image.open(os.path.join(inputDir, faces[f]))
     for level in range(levels, 0, -1):
         if not os.path.exists(os.path.join(args.output, str(level))):
             os.makedirs(os.path.join(args.output, str(level)))
@@ -128,14 +161,14 @@ print('Generating fallback tiles...')
 for f in range(0, 6):
     if not os.path.exists(os.path.join(args.output, 'fallback')):
         os.makedirs(os.path.join(args.output, 'fallback'))
-    face = Image.open(os.path.join(args.output, faces[f]))
+    face = Image.open(os.path.join(inputDir, faces[f]))
     face = face.resize([1024, 1024], Image.ANTIALIAS)
     face.save(os.path.join(args.output, 'fallback', faceLetters[f] + extension), quality = args.quality)
 
 # Clean up temporary files
-os.remove(os.path.join(args.output, 'cubic.pto'))
-for face in faces:
-    os.remove(os.path.join(args.output, face))
+if removeFaces:
+    for face in faces:
+        os.remove(os.path.join(args.output, face))
 
 # Generate config file
 text = []


### PR DESCRIPTION
Hello,
I've modified the generates.py file in order to take cube faces as input.
my workflow is as follow : after generating the cubes faces from the equirectangular image, I edit the down face and then I make tiles from the cube faces. I usually delete the equirectangular image since it becomes useless.
as I found it inadequate to build up the equirectangular image from the cube faces to comply with generates.py's input, I decied to modify it to accept cube faces as input.
if the input is a directory, it must contain 6 files whose first letters are in "fbudlr".
Hope it helps,
Franck