### PR TITLE
Device orientation API

### DIFF
--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -118,6 +118,13 @@ viewer can be set to. Defaults to `50` / `120`.
 
 If `true`, a compass is displayed. Defaults to `false`.
 
+### `enableDeviceOrientationCtrl`
+
+*experimental*
+
+If `true`, the panorama can be viewed by panning of your device (only on devices that support the device orientation api).
+This feature can be enabled by clicking the button that appears if it is available or clicking the compass.
+If a correct northOffset is specified this will align the image with the compass if the device provides compass data.
 
 ### `northOffset`
 

--- a/src/css/img/sprites.svg
+++ b/src/css/img/sprites.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="26" height="156">
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="208">
 <circle fill-opacity=".78" cy="117" cx="13" r="11" fill="#fff"/>
 <circle fill-opacity=".78" cy="143" cx="13" r="11" fill="#fff"/>
 <path d="m5 83v6h2v-4h4v-2h-6zm10 0v2h4v4h2v-6h-6zm-5 5v6h6v-6h-6zm-5 5v6h6v-2h-4v-4h-2zm14 0v4h-4v2h6v-6h-2z"/>
@@ -7,4 +7,7 @@
 <path d="m17 37.9998v2h-8v-2z"/>
 <path d="m12 9v3h-3v2h3v3h2v-3h3v-2h-3v-3h-2z"/>
 <path d="m13 136-6.125 6.125h4.375v7.875h3.5v-7.875h4.375z"/>
+<path d="m15 175.53s5.53-5.83 4.02-7.14c-1.5-1.32-3 .87-3 .87s3.12-4.96 1.22-5.63c-1.9-.66-2.9 3.78-2.9 3.78s.77-5-.9-5c-1.68 0-1.38 4.68-1.38 4.68s-.5-3.98-1.9-3.57c-1.38.4-.48 4.77-.48 4.77s-1.37-4.23-2.54-3.28c-1.17.96.22 4.55.5 5.74.72 2.1 1.75 2.54 1.88 4.8" stroke="#000" fill="#fff" stroke-width=".9"/>
+<circle cy="195" cx="13" r="7.5" fill="#fff" stroke-width="1" stroke="#000"/>
+<path d="m12.74 189.03l-1.7 5.66h3.92l-1.7-5.67zm-1.7 6.28l1.7 5.67h.52l1.7-5.66zm.62.52h2.68L13 200.06z"/>
 </svg>

--- a/src/css/pannellum.css
+++ b/src/css/pannellum.css
@@ -114,6 +114,21 @@
     background-position: 0 -78px;
 }
 
+.pnlm-deviceorientation-toggle-button {
+    top: 102px;
+    left: 4px;
+    width: 26px;
+    height: 26px;
+}
+
+.pnlm-deviceorientation-toggle-button-inactive {
+    background-position: 0 -182px;
+}
+
+.pnlm-deviceorientation-toggle-button-active {
+    background-position: 0 -156px;
+}
+
 .pnlm-panorama-info {
     position: absolute;
     bottom: 4px;

--- a/src/js/deviceOrientation.js
+++ b/src/js/deviceOrientation.js
@@ -1,0 +1,133 @@
+/*
+ * Device Orientation Handler for Pannellum
+ * Copyright (c) 2016 Markus Breunig
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Handler for device orientation events.
+ * The events will be handled and converted to Yaw and Pitch.
+ * 
+ * @param fctAvailability(bool bAvailable) is called as soon as the availability was determined
+ * 
+ * Availability will be true, wenn device orientation is available and values are absolute in earth frame.
+ * 
+ * Yaw: -180,180 (180 is north)
+ * Pitch: -90,90 (90 bottom, -90 top)
+ */
+var DeviceOrientationHandler = function( fctAvailability ) {
+	
+	var fctAvailability = fctAvailability;
+	
+	var _this = this;
+	
+	var data = null;
+	var availabilityCheckTryCount = 0;
+	var availabilityCheckInterval = null;
+	
+	var degtorad = Math.PI / 180; // Degree-to-Radian conversion
+	
+	/**
+	 * Get raw data as returned by event
+	 */
+	this.GetRaw = function() {
+		return data;
+	}
+	
+	/**
+	 * Get the yaw of the last updated device orientation.
+	 * @return Pitch [-360,360) 
+	 */
+	this.GetYaw = function() {
+		// source: http://w3c.github.io/deviceorientation/spec-source-orientation.html
+
+		var _x = data.beta  ? data.beta  * degtorad : 0; // beta value
+		var _y = data.gamma ? data.gamma * degtorad : 0; // gamma value
+		var _z = data.alpha ? data.alpha * degtorad : 0; // alpha value
+
+		var cX = Math.cos( _x );
+		var cY = Math.cos( _y );
+		var cZ = Math.cos( _z );
+		var sX = Math.sin( _x );
+		var sY = Math.sin( _y );
+		var sZ = Math.sin( _z );
+
+		// Calculate Vx and Vy components
+		var Vx = - cZ * sY - sZ * sX * cY;
+		var Vy = - sZ * sY + cZ * sX * cY;
+
+		// Calculate compass heading
+		var compassHeading = Math.atan( Vx / Vy );
+
+		// Convert compass heading to use whole unit circle
+		if( Vy < 0 ) {
+			compassHeading += Math.PI;
+		} else if( Vx < 0 ) {
+			compassHeading += 2 * Math.PI;
+		}
+		
+		// convert range  to [-PI,PI]
+		compassHeading -= Math.PI;
+
+		return compassHeading / degtorad; // Compass Heading (in degrees)
+	}
+
+	/**
+	 * Get the pitch of the last updated device orientation.
+	 * @return Pitch [-90,90) 
+	 */
+	this.GetPitch = function() {
+		var _x = data.beta  ? data.beta  * degtorad : 0; // beta value
+		var _y = data.gamma ? data.gamma * degtorad : 0; // gamma value
+		var _z = data.alpha ? data.alpha * degtorad : 0; // alpha value
+		
+		var pitch = Math.asin(-Math.cos(_x)*Math.cos(_y));
+		
+		return pitch / degtorad;
+	}
+	
+	this.UpdateOrientation = function(e) {
+		data = e;
+	}
+	
+	/**
+	 * This function is called to check if the device orientation data was provided
+	 * and notifies the client about the availability.
+	 */
+	this.CheckAvailability = function() {
+	    if(data !== null && data.alpha !== null && data.absolute === true){
+	        // Clear interval
+	        clearInterval(availabilityCheckInterval);
+	        availabilityCheckInterval = null;
+	        fctAvailability(true);
+	    }else{
+	        availabilityCheckTryCount++;
+	        if(availabilityCheckTryCount === 10) {
+	            // Clear interval
+	            clearInterval(availabilityCheckInterval);
+	            fctAvailability(false);
+	        }
+	    }
+	}
+	
+	window.addEventListener('deviceorientation', function(e) { _this.UpdateOrientation(e); } );
+	
+	availabilityCheckInterval = window.setInterval(function() { _this.CheckAvailability(); }, 200 );
+}

--- a/src/standalone/pannellum.htm
+++ b/src/standalone/pannellum.htm
@@ -17,6 +17,7 @@
 <script type="text/javascript" src="../js/libpannellum.js"></script>
 <script type="text/javascript" src="../js/RequestAnimationFrame.js"></script>
 <script type="text/javascript" src="../js/pannellum.js"></script>
+<script type="text/javascript" src="../js/deviceOrientation.js"></script>
 <script type="text/javascript" src="standalone.js"></script>
 </body>
 </html>

--- a/utils/build/build.py
+++ b/utils/build/build.py
@@ -10,6 +10,7 @@ JS = [
 'js/libpannellum.js',
 'js/RequestAnimationFrame.js',
 'js/pannellum.js',
+'js/deviceOrientation.js',
 ]
 
 CSS = [


### PR DESCRIPTION
I added the device orientation API to pannellum so a mobile phone user can view the panorama by tilting of the phone if the new button or the compass is clicked. Since the specification of W3C is still a draft I marked this feature as experimental.

So far I was able to test it with Chrome and Firefox on Android.
Firefox doesn't behave like the specification and the image suddenly rotates 180° at certain points in landscape mode. At the moment I am not able to investigate it any further since Firefox is blocking WebGL on my phone.