### PR TITLE
Fix wrong aspect ration on OS X Safari

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1680,6 +1680,8 @@ function onFullScreenChange() {
     if (document.fullscreen || document.mozFullScreen || document.webkitIsFullScreen || document.msFullscreenElement) {
         controls.fullscreen.classList.add('pnlm-fullscreen-toggle-button-active');
         fullscreenActive = true;
+        // Fix wrong aspect ration on OS X Safari: https://github.com/mpetroff/pannellum/issues/155
+        renderer.resize(); render();
     } else {
         controls.fullscreen.classList.remove('pnlm-fullscreen-toggle-button-active');
         fullscreenActive = false;


### PR DESCRIPTION
This fixes https://github.com/mpetroff/pannellum/issues/155. I'm sure it can be done more elegantly but it should point you in the right direction, basically recalculate aspect ration after full screen was entered and render one frame so that screen does not stay black.