### PR TITLE
Enable additional URL configuration parameters

### DIFF
--- a/doc/url-config-parameters.md
+++ b/doc/url-config-parameters.md
@@ -14,6 +14,7 @@ Specifies the URL of a JSON configuration file.
 ## Other parameters
 
 A subset of the JSON configuration file options can be used as URL parameters.
-These include `panorama`, `config`, `author`, `title`, `hfov`, `pitch`, `yaw`,
+These include `panorama`, `config`, `author`, `title`, `hfov`, `minHfov`, `maxHfov`,
+`pitch`, `minPitch`, `maxPitch`, `yaw`, `minYaw`, `maxYaw`,
 `haov`, `vaov`, `vOffset`, `autoLoad`, `autoRotate`, `firstScene`,
 `ignoreGPanoXMP`, `preview`, and `fallback`.

--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -21,6 +21,7 @@ function parseURLParameters() {
         json += '"' + option + '":';
         switch(option) {
             case 'hfov': case 'pitch': case 'yaw': case 'haov': case 'vaov':
+            case 'minHfov': case 'maxHfov': case 'minPitch': case 'maxPitch': case 'minYaw': case 'maxYaw':
             case 'vOffset': case 'autoRotate':
                 json += value;
                 break;


### PR DESCRIPTION
I would suggest adding support for the following parameters from URL config:
  - minHfov, maxHfov
  - minPitch, maxPitch
  - minYaw, maxYaw

The motivation for this was making it easier to create auto-generated
panoramas using Jekyll/Hugo and other static site generators without
needing to create JSON files for panoramas.

If a given panorama is not a full 360x180 panorama, then the above
parameters are needed in addition to haov and vaov parameters
in order for the user not to see black areas in the panorama.
Hence suggesting adding URL support.