### PR TITLE
Add JS methods for starting and stopping autoRotate

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2053,6 +2053,28 @@ this.setNorthOffset = function(heading) {
 };
 
 /**
+ * Start autoRotate.
+ * @memberof Viewer
+ * @instance
+ * @returns {Viewer} `this`
+ */
+this.startAutoRotate = function() {
+    config.autoRotate = true;
+    return this;
+};
+
+/**
+ * Stop autoRotate.
+ * @memberof Viewer
+ * @instance
+  * @returns {Viewer} `this`
+ */
+this.stopAutoRotate = function() {
+    config.autoRotate = false;
+    return this;
+};
+
+/**
  * Returns the panorama renderer.
  * @memberof Viewer
  * @instance

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2067,7 +2067,7 @@ this.startAutoRotate = function() {
  * Stop autoRotate.
  * @memberof Viewer
  * @instance
-  * @returns {Viewer} `this`
+ * @returns {Viewer} `this`
  */
 this.stopAutoRotate = function() {
     config.autoRotate = false;


### PR DESCRIPTION
I didn't find a way to toggle `config.autoRotate` from JavaScript, so I created two methods to do it. I'm not sure if this is useful to anyone else, but I figured I'd open a PR.

Thanks for a great library!