### PR TITLE
Added function to add hotspot to another scene

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2455,6 +2455,23 @@ this.addHotSpot = function(hs) {
 }
 
 /**
+ * Add a new hot spot to a specific scene.
+ * @memberof Viewer
+ * @instance
+ * @param {string} sceneId - The scene where to add the hot spot
+ * @param {Object} hs - The configuration for the hot spot
+ * @returns {boolean} True if the add was successful, else false
+ */
+this.addHotSpotToScene = function(sceneId, hs) {
+    // TODO: do some checks if it is the actual scene
+    if (initialConfig.scenes.hasOwnProperty(sceneId)) {
+        initialConfig.scenes[sceneId].hotSpots.push(hs);
+        return true;
+    }
+    return false;
+}
+
+/**
  * Remove a hot spot.
  * @memberof Viewer
  * @instance


### PR DESCRIPTION
I have added a function to add hotspot to another scene. The single problem is what to do if the scene is the current scene? A way would be to call `addHotSpot`( if can call it) or just return `false` and the user should figure out what he needs to do in that case.

EDIT: I forgot to add the check if `hotSpot` array does not exists.