### PR TITLE
Hotspots and javascript execution

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1593,6 +1593,22 @@ function createHotSpot(hs) {
         div.style.cursor = 'pointer';
         span.style.cursor = 'pointer';
         a.appendChild(div);
+    } else if (hs.action) {
+        a = document.createElement('a');
+        a.href = "#";
+	a.ontouchstart = function() {
+		this.touchAvailable = true;
+		hs.action();
+	};
+	a.onclick = function() {
+		if (!this.touchAvailable) {
+			hs.action();
+		}
+	};
+        renderContainer.appendChild(a);
+        div.style.cursor = 'pointer';
+        span.style.cursor = 'pointer';
+        a.appendChild(div);
     } else {
         if (hs.sceneId) {
             div.onclick = function() {


### PR DESCRIPTION
Add functionality to execute javascript functions when clicking or touching on hotspots

`"hotSpots": [
        {
            "pitch": 14.1,
            "yaw": 1.5,
            "type": "info",
            "text": "Art Museum Drive",
            "action": function() { console.log("Hotspot action!"); }
        }
]`