### PR TITLE
Added doubleclick zoom functionality

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -409,7 +409,7 @@ function onImageLoad() {
     if (!listenersAdded) {
         listenersAdded = true;
         dragFix.addEventListener('mousedown', onDocumentMouseDown, false);
-        container.addEventListener('dblclick', onDocumentDoubleClick, false);
+        dragFix.addEventListener('dblclick', onDocumentDoubleClick, false);
         document.addEventListener('mousemove', onDocumentMouseMove, false);
         document.addEventListener('mouseup', onDocumentMouseUp, false);
         if (config.mouseZoom) {
@@ -2613,6 +2613,7 @@ this.destroy = function() {
         renderer.destroy()
     if (listenersAdded) {
         dragFix.removeEventListener('mousedown', onDocumentMouseDown, false);
+        dragFix.removeEventListener('dblclick', onDocumentDoubleClick, false);
         document.removeEventListener('mousemove', onDocumentMouseMove, false);
         document.removeEventListener('mouseup', onDocumentMouseUp, false);
         container.removeEventListener('mousewheel', onDocumentMouseWheel, false);

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -89,6 +89,7 @@ var defaultConfig = {
     northOffset: 0,
     showFullscreenCtrl: true,
     dynamic: false,
+    doubleClickZoom: true,
     keyboardZoom: true,
     mouseZoom: true,
     showZoomCtrl: true,
@@ -409,12 +410,14 @@ function onImageLoad() {
     if (!listenersAdded) {
         listenersAdded = true;
         dragFix.addEventListener('mousedown', onDocumentMouseDown, false);
-        dragFix.addEventListener('dblclick', onDocumentDoubleClick, false);
         document.addEventListener('mousemove', onDocumentMouseMove, false);
         document.addEventListener('mouseup', onDocumentMouseUp, false);
         if (config.mouseZoom) {
             container.addEventListener('mousewheel', onDocumentMouseWheel, false);
             container.addEventListener('DOMMouseScroll', onDocumentMouseWheel, false);
+        }
+        if (config.doubleClickZoom) {
+            dragFix.addEventListener('dblclick', onDocumentDoubleClick, false);
         }
         container.addEventListener('mozfullscreenchange', onFullScreenChange, false);
         container.addEventListener('webkitfullscreenchange', onFullScreenChange, false);


### PR DESCRIPTION
I've ran some user tests on older users, and when asked to zoom in every single one of them tried to double click on the object of interest. I've added the doubleclick zoom-in as default functionality that can be turned off in the config. I've ensured that it does not interfere with rapidly clicking on UI elements.

I can change this functionality to default to off if you prefer. Also, my editor (Atom) deleted some whitespace automatically. I don't think it's a big deal but I can revert it and resubmit the pull request if needed.

Lastly, I've discovered a bug that has existed even before my changes. Double clicking on a scene change arrow will cause the panorama to not render properly. I will submit an issue for it.