### PR TITLE
Provide fallback cursor

### DIFF
--- a/src/css/pannellum.css
+++ b/src/css/pannellum.css
@@ -24,10 +24,12 @@
 }
 
 .pnlm-grab {
+    cursor: grab;
     cursor: url('img/grab.svg') 12 8, default;
 }
 
 .pnlm-grabbing {
+    cursor: grabbing;
     cursor: url('img/grabbing.svg') 12 8, default;
 }
 


### PR DESCRIPTION
Provide fallback grabbing hands for browsers without cursor svg data uri support.

Fixes #317.