### PR TITLE
Language configuration option for titles and hotspot text

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1592,6 +1592,11 @@ function createHotSpot(hs) {
     var span = document.createElement('span');
     if (hs.text)
         span.innerHTML = escapeHTML(hs.text);
+        if(config.hasOwnProperty('language')){
+          if(hs.hasOwnProperty('text_' + config['language'])){
+            span.innerHTML = escapeHTML(hs['text_' + config['language']]);
+          }
+        }
 
     var a;
     if (hs.video) {
@@ -1849,6 +1854,11 @@ function processOptions(isPreview) {
             case 'title':
                 infoDisplay.title.innerHTML = escapeHTML(config[key]);
                 infoDisplay.container.style.display = 'inline';
+                if(config.hasOwnProperty('language')){
+                  if(config.hasOwnProperty('title_' + config['language'])){
+                    infoDisplay.title.innerHTML = escapeHTML(config['title_' + config['language']]);
+                  }
+                }
                 break;
             
             case 'author':


### PR DESCRIPTION
Hello,
This is my first pull request ever so my apologies if I've done anything wrong (please let me know and I'll try again).

I need multi-language support for titles and hotspot text for a project I am working on.  I've added an optional config entry 'language'.  If it is set to something (say 'fr'), pannellum will look for title_fr and text_fr for each scene and each hotspot.  If no language is set or no special title or text is included it will default to the title and text variables.