### PR TITLE
Make scrollable in touch only device when config.draggable is false

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -803,6 +803,10 @@ function onDocumentTouchStart(event) {
  * @param {TouchEvent} event - Document touch move event.
  */
 function onDocumentTouchMove(event) {
+    if (!config.draggable) {
+        return;
+    }
+
     // Override default action
     event.preventDefault();
     if (loaded) {


### PR DESCRIPTION
Meet a problem when using new draggable option.

I made a viewer take up entire viewport and rotate follow my cursor. (without click)

It works in desktop with mouse, but in mobile phone, I can't scroll down my page because viewer consumed the touchmove event.

Since viewer don't need to response to mousemove event when draggable is false, I think it's fine to simply return.