### PR TITLE
Set basePath correctly when the config location is specified as url parameter

### DIFF
--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -66,7 +66,7 @@ function parseURLParameters() {
 
             // Set JSON file location
             if (responseMap.basePath === undefined)
-                responseMap.basePath = configFromURL.config.substring(0, configFromURL.config.lastIndexOf('/')+1);
+                responseMap.basePath = configFromURL.config.substring(0, configFromURL.config.lastIndexOf('/'));
 
             // Merge options
             for (var key in responseMap) {


### PR DESCRIPTION
When the config is passed as url parameter and the config object does not contain as basePath, a wrong basePath was extracted from the config url.

Example: 

https://mybucket.s3.eu-central-1.amazonaws.com/pannellum/pannellum.htm?config=https://mybucket.s3.eu-central-1.amazonaws.com/imageSubFolder/output/config.json&autoLoad=true

Image urls generated without this fix (leads to 403 on Amazon S3): https://mybucket.s3.eu-central-1.amazonaws.com/imageSubFolder/output//1/r0_0.jpg (notice the duplicate // at the end)

Image urls generated with this fix (working fine on Amazon S3): https://mybucket.s3.eu-central-1.amazonaws.com/imageSubFolder/output/1/r0_0.jpg