### PR TITLE
Fix removing event listener inside listener

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2716,8 +2716,9 @@ this.off = function(type, listener) {
  */
 function fireEvent(type) {
     if (type in externalEventListeners) {
-        for (var i = 0; i < externalEventListeners[type].length; i++) {
-            externalEventListeners[type][i].apply(null, [].slice.call(arguments, 1));
+        // Reverse iteration is useful, if event listener is removed inside its definition
+        for (var i = externalEventListeners[type].length; i > 0; i--) {
+            externalEventListeners[type][externalEventListeners[type].length - i].apply(null, [].slice.call(arguments, 1));
         }
     }
 }


### PR DESCRIPTION
It's a common situation to remove an event listener inside its definition. Like this:
```javascript
viewer.on('load', function foo() {
	//code
	viewer.off('load', foo);
});
```

In this case `off` function removes the item from `externalEventListeners` array, while looping through this array may be not finished in `fireEvent` function. A reverse iteration fixes it.
Since we'd like to fire listeners in the order they were added, we need to use `externalEventListeners[type].length - i` index.