### PR TITLE
Use absolute position for ui element.

### DIFF
--- a/src/css/pannellum.css
+++ b/src/css/pannellum.css
@@ -24,7 +24,7 @@
 }
 
 .pnlm-ui {
-    position: relative;
+    position: absolute;
     width: 100%;
     height: 100%;
     z-index: 1;


### PR DESCRIPTION
During testing I noticed that the ui element should be rather absolutely positioned than relatively positioned. Somehow slipped through the last PR merge.