### PR TITLE
adding config to change loading text

### DIFF
--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -170,6 +170,11 @@ Specifies the author to be displayed while the load button is displayed.
 Label to display on load button. Defaults to `Click to Load Panorama`.
 
 
+### `loadingLabel` (string)
+
+Label to display on the loading box. Defaults to `Loading...`.
+
+
 ### `horizonPitch` and `horizonRoll` (number)
 
 Specifies pitch / roll of image horizon, in degrees (for correcting

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -101,6 +101,7 @@ var defaultConfig = {
     backgroundColor: [0, 0, 0],
     animationTimingFunction: timingFunction,
     loadButtonLabel: 'Click to\nLoad\nPanorama',
+    loadingLabel: 'Loading...',
     draggable: true,
 };
 
@@ -154,7 +155,6 @@ uiContainer.appendChild(infoDisplay.container);
 infoDisplay.load = {};
 infoDisplay.load.box = document.createElement('div');
 infoDisplay.load.box.className = 'pnlm-load-box';
-infoDisplay.load.box.innerHTML = '<p>Loading...</p>';
 infoDisplay.load.lbox = document.createElement('div');
 infoDisplay.load.lbox.className = 'pnlm-lbox';
 infoDisplay.load.lbox.innerHTML = '<div class="pnlm-loading"></div>';
@@ -1943,6 +1943,10 @@ function processOptions(isPreview) {
 
             case 'loadButtonLabel':
                 controls.load.innerHTML = '<p>' + escapeHTML(config[key]) + '</p>';
+                break;
+
+            case 'loadingLabel':
+                infoDisplay.load.box.innerHTML = '<p>' + escapeHTML(config[key]) + '</p>';
                 break;
         }
       }


### PR DESCRIPTION
This adds the option to change the text on the loading box when loading a panorama. It defaults to the old "Loading..." message, but can be changed to other texts. Helps if you want a different message, specially if you want it in another language. I figured `loadingLabel` is a good enough name for the config.