### PR TITLE
Add proper way to translate all occurring strings via dictionary

### DIFF
--- a/src/css/pannellum.css
+++ b/src/css/pannellum.css
@@ -268,6 +268,7 @@
 .pnlm-load-button p {
     display: table-cell;
     vertical-align: middle;
+    padding: 1em;
 }
 
 .pnlm-info-box {

--- a/src/js/libpannellum.js
+++ b/src/js/libpannellum.js
@@ -42,6 +42,9 @@ function Renderer(container) {
     var pose;
     var image, imageType, dynamic;
     var texCoordBuffer, cubeVertBuf, cubeVertTexCoordBuf, cubeVertIndBuf;
+    // based on ISO 639-1: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+    // defaults to 'en' => english
+    var languageCode;
 
     /**
      * Initialize renderer.
@@ -59,16 +62,20 @@ function Renderer(container) {
      * @param {number} vaov - Initial vertical angle of view.
      * @param {number} voffset - Initial vertical offset angle.
      * @param {function} callback - Load callback function.
-     * @param {Object} [params] - Other configuration parameters (`horizonPitch`, `horizonRoll`, `backgroundColor`).
+     * @param {Object} [params] - Other configuration parameters (`horizonPitch`, `horizonRoll`, `backgroundColor`, `languageCode`).
      */
     this.init = function(_image, _imageType, _dynamic, haov, vaov, voffset, callback, params) {
+        // set language code for localized strings
+        // defaults to english if not set!
+        languageCode = params.languageCode ? params.languageCode : 'en';
+        
         // Default argument for image type
         if (typeof _imageType === undefined)
             _imageType = 'equirectangular';
 
         if (_imageType != 'equirectangular' && _imageType != 'cubemap' &&
             _imageType != 'multires') {
-            console.log('Error: invalid image type specified!');
+            console.log(STRINGS.ERROR_INVALID_IMG_TYPE[languageCode]);
             throw {type: 'config error'};
         }
 
@@ -225,7 +232,7 @@ function Renderer(container) {
             
             return;
         } else if (!gl) {
-            console.log('Error: no WebGL support detected!');
+            console.log(STRINGS.ERROR_NO_WEBGL[languageCode]);
             throw {type: 'no webgl'};
         }
         if (image.basePath) {
@@ -248,14 +255,14 @@ function Renderer(container) {
             width = Math.max(image.width, image.height);
             maxWidth = gl.getParameter(gl.MAX_TEXTURE_SIZE);
             if (width > maxWidth) {
-                console.log('Error: The image is too big; it\'s ' + width + 'px wide, but this device\'s maximum supported width is ' + maxWidth + 'px.');
+                console.log(STRINGS.ERROR_IMG_TOO_BIG[languageCode] + " " + STRINGS.TEXT_IMG_SUPPORTED_WIDTH[languageCode] + maxWidth + "px.");
                 throw {type: 'webgl size error', width: width, maxWidth: maxWidth};
             }
         } else if (imageType == 'cubemap') {
             width = image[0].width;
             maxWidth = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
             if (width > maxWidth) {
-                console.log('Error: The cube face image is too big; it\'s ' + width + 'px wide, but this device\'s maximum supported width is ' + maxWidth + 'px.');
+                console.log(STRINGS.ERROR_CUBE_FACE_TOO_BIG[languageCode] + " " + STRINGS.TEXT_IMG_SUPPORTED_WIDTH[languageCode] + maxWidth + "px.");
                 throw {type: 'webgl size error', width: width, maxWidth: maxWidth};
             }
         }
@@ -408,7 +415,7 @@ function Renderer(container) {
         // Check if there was an error
         var err = gl.getError();
         if (err !== 0) {
-            console.log('Error: Something went wrong with WebGL!', err);
+            console.log(STRINGS.ERROR_WEBGL[languageCode], err);
             throw {type: 'webgl error'};
         }
 
@@ -1186,7 +1193,7 @@ function Renderer(container) {
      * @private
      */
     function handleWebGLError1286() {
-        console.log('Reducing canvas size due to error 1286!');
+        console.log(STRINGS.ERROR_WEBGL_1286[languageCode]);
         canvas.width = Math.round(canvas.width / 2);
         canvas.height = Math.round(canvas.height / 2);
     }

--- a/src/js/strings.js
+++ b/src/js/strings.js
@@ -2,7 +2,7 @@ var STRINGS = {
     "ERROR_INVALID_IMG_TYPE": {
         "de": "Error: Falscher Bild-Typ angegeben!",
         "en": "Error: invalid image type specified!",
-        "ru": "Ошибка: неправильный тип Изображение!"
+        "ru": "Ошибка: неправильный тип изображения!"
     },
     "ERROR_IMG_TOO_BIG": {
         "de": "Error: Das Bild ist zu groß. Ihr Gerät unterstützt dies nicht.",

--- a/src/js/strings.js
+++ b/src/js/strings.js
@@ -2,11 +2,91 @@ var STRINGS = {
     "ERROR_INVALID_IMG_TYPE": {
         "de": "Error: Falscher Bild-Typ angegeben!",
         "en": "Error: invalid image type specified!",
-        "ru": "ошибка: неправильный фото тип!"
+        "ru": "Ошибка: неправильный тип Изображение!"
+    },
+    "ERROR_IMG_TOO_BIG": {
+        "de": "Error: Das Bild ist zu groß. Ihr Gerät unterstützt dies nicht.",
+        "en": "Error: The image is too big; Your device does not support it.",
+        "ru": "Ошибка: Разрешение этого изображения слишком велико. Ваш прибор это не поддерживает."
+    },
+    "ERROR_CUBE_FACE_TOO_BIG": {
+        "de": "Error: Das Cube Face ist zu groß. Ihr gerät unterstützt dies nicht.",
+        "en": "Error: The cube face is too big; Your device does not support it.",
+        "ru": "Ошибка: Изображение верхней стороны кубика слишком велико. Ваш прибор это не поддерживает."
     },
     "ERROR_NO_WEBGL": {
         "de": "Error: WebGL wird nicht unterstützt!",
         "en": "Error: no WebGL support detected!",
-        "ru": "ошибка: нет функции WebGL!"
+        "ru": "Ошибка: WebGL не поддерживается!"
+    },
+    "ERROR_WEBGL": {
+        "de": "Error: Ein WebGL Fehler ist aufgetreten!",
+        "en": "Error: Something went wrong with WebGL!",
+        "ru": "Ошибка: WebGL Ошибка!"
+    },
+    "ERROR_WEBGL_1286": {
+        "de": "Error: Verkleinere Canvas wegen Error 1286!",
+        "en": "Error: Reducing canvas size due to error 1286!",
+        "ru": "Ошибка: Из за ошибки 1286 уменьшаю изображение на экране."
+    },
+    "ERROR_NO_PANORAMA": {
+        "de": "Error: Es wurde kein Panorama angegeben.",
+        "en": "Error: No panorama image was specified.",
+        "ru": "Ошибка: Панорама не найдена."
+    },
+    "ERROR_FILE_ACCESS": {
+        "de": "Error: Datei konnte nicht geöffnet werden.",
+        "en": "Error: File could not be accessed.",
+        "ru": "Ошибка: Файл не открывается."
+    },
+    "ERROR_PANORAMA_URL": {
+        "de": "Error: Da stimmt etwas nicht mit der Panorama URL.",
+        "en": "Error: There is something wrong with the panorama URL.",
+        "ru": "Ошибка: URL Панорамы повреждён."
+    },
+    "ERROR_IOS8_WEBGL": {
+        "de": "Error: Wegen der fehlerhaften WebGL Implementierung von iOS8, funktionieren nur progressiv enkodierte JPEGs auf ihrem Gerät (dieses Panorama benutzt standard Enkodierung).",
+        "en": "Error: Due to iOS 8's broken WebGL implementation, only progressive encoded JPEGs work for your device (this panorama uses standard encoding).",
+        "ru": "Ошибка: Из за ошибочной WebGL реализации в iOS8, на вашем  приборе работают только прогрессивно кодированные JPEGs. (Для этой Панорамы используется стандартная кодировка.)"
+    },
+    "ERROR_UNKNOWN": {
+        "de": "Error: Ein unbekannter Fehler ist aufgetreten. Schauen Sie in die Entwicklerkonsole.",
+        "en": "Error: An unknown error occured. Check developer console.",
+        "ru": "Ошибка: Произошла неизвестная ошибка. Обратитесь в консоль разработчика."
+    },
+    "ERROR_HFOV_BOUNDS": {
+        "de": "Error: HFOV Grenzen machen keinen Sinn (minHfov > maxHfov).",
+        "en": "Error: HFOV bounds do not make sense (minHfov > maxHfov).",
+        "ru": "Ошибка: HFOV границы не имеют смысла(minHfov > maxHfov)."
+    },
+    "ERROR_INVALID_SCENE_ID": {
+        "de": "Error: Falsche scene ID!",
+        "en": "Error: Invalid scene ID!",
+        "ru": "Ошибка: неправильный идентификатор сцены!"
+    },
+    "TEXT_IMG_SUPPORTED_WIDTH": {
+        "de": "Die maximal unterstützte Breite für ihr Gerät ist: ",
+        "en": "This device's maximum supported width is: ",
+        "ru": "Максимально поддерживаемая ширина изображения для вашего прибора: "
+    },
+    "TEXT_IMG_TOO_BIG_ADVICE": {
+        "de": "(Falls Sie der Author sind, versuchen Sie das Bild herunterzuskalieren.)",
+        "en": "(If you're the author, try scaling down the image.)",
+        "ru": "(Если Вы являетесь автором, попробуйте уменьшить разрешение изображения.)"
+    },
+    "TEXT_CLICK_TO_LOAD": {
+        "de": "Klicke um\nPanorama\nzu laden",
+        "en": "Click to\nLoad\nPanorama",
+        "ru": "нажмите здесь чтобы\nзагрузить\nпанораму"
+    },
+    "TEXT_ALTERNATIVE_VIEWER": {
+        "de": "Klicken Sie hier um das Panorama über einen alternativen Weg anzuschauen.",
+        "en": "Click here to view this panorama in an alternative viewer.",
+        "ru": "Нажмите здесь, чтобы увидеть Панораму по другому."
+    },
+    "TEXT_BY": {
+        "de": "von",
+        "en": "by",
+        "ru": "от"
     }
 }

--- a/src/js/strings.js
+++ b/src/js/strings.js
@@ -1,0 +1,12 @@
+var STRINGS = {
+    "ERROR_INVALID_IMG_TYPE": {
+        "de": "Error: Falscher Bild-Typ angegeben!",
+        "en": "Error: invalid image type specified!",
+        "ru": "ошибка: неправильный фото тип!"
+    }
+    //,
+    // "ERROR_NO_WEBGL": {
+    //     "de": "...",
+    //     "en": "..."
+    // }
+}

--- a/src/js/strings.js
+++ b/src/js/strings.js
@@ -3,10 +3,10 @@ var STRINGS = {
         "de": "Error: Falscher Bild-Typ angegeben!",
         "en": "Error: invalid image type specified!",
         "ru": "ошибка: неправильный фото тип!"
+    },
+    "ERROR_NO_WEBGL": {
+        "de": "Error: WebGL wird nicht unterstützt!",
+        "en": "Error: no WebGL support detected!",
+        "ru": "ошибка: нет функции WebGL!"
     }
-    //,
-    // "ERROR_NO_WEBGL": {
-    //     "de": "...",
-    //     "en": "..."
-    // }
 }

--- a/src/standalone/pannellum.htm
+++ b/src/standalone/pannellum.htm
@@ -15,6 +15,7 @@
     </div>
   </noscript>
 </div>
+<script type="text/javascript" src="../js/strings.js"></script>
 <script type="text/javascript" src="../js/libpannellum.js"></script>
 <script type="text/javascript" src="../js/RequestAnimationFrame.js"></script>
 <script type="text/javascript" src="../js/pannellum.js"></script>

--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -37,7 +37,7 @@ function parseURLParameters() {
                 configFromURL[option] = JSON.parse(value);
                 break;
             case 'author': case 'title': case 'firstScene': case 'fallback':
-            case 'preview': case 'panorama': case 'config':
+            case 'preview': case 'panorama': case 'config': case 'languageCode':
                 configFromURL[option] = decodeURIComponent(value);
                 break;
             default:

--- a/utils/build/build.py
+++ b/utils/build/build.py
@@ -7,6 +7,7 @@ import subprocess
 import urllib.parse
 
 JS = [
+'js/strings.js',
 'js/libpannellum.js',
 'js/RequestAnimationFrame.js',
 'js/pannellum.js',


### PR DESCRIPTION
Hey @mpetroff !

I implemented translatable strings. I already provided full translation in german and russian!

I personally tested it and played around with it. It defaults to english if no language is set. 

One can setup the language via the field "languageCode" inside the config or via URL parameter when using the standalone version.  A list of the ISO 639-1 codes can be seen [here](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).

**One thing though**: I - for now - ignored the strings inside the `standalone.js`. I'd like to handle this as follow up commits after your feedback. **How would you implement that there?** At the point of URL parameter parsing, the languageCode could come after an error occurs. Printing english first and switching language midway, after the languageCode is set, is easily doable but could look messy and or unprofessional. 
______

I asked myself whether there should be checks inside of pannellum when the user types in an unsupported languageCode like "abc"? That results in strings saying 'undefined' and thats just ugly. I think the user is responsible for writing in a proper languageCode though. **Whats your take on this?**

I thought about 2 different ways one could structure the dictionary.

1. Constant name first, language code second
```
"ERROR_INVALID_IMG_TYPE": {
        "de": "Error: Falscher Bild-Typ angegeben!",
        "en": "Error: invalid image type specified!",
        "ru": "Ошибка: неправильный тип Изображение!"
    }
```
2. language code first, constant name second
```
"de": {
    "ERROR_INVALID_IMG_TYPE": "Error: Falscher Bild-Typ angegeben!"
    },
"en": {
    "ERROR_INVALID_IMG_TYPE": "Error: invalid image type specified!"
    },
"ru": {
    "ERROR_INVALID_IMG_TYPE": "Ошибка: неправильный тип Изображение!"
    }
```

As you can see in the commits, I chose the first option because I think it is cleaner, easier to translate when you see other languages side by side, you can search properly for the constant-name via ctrl+f and the file is generally kept smaller because you dont have to repeat the constants all the time.

And lastly, **are you concerned about language-bloat?** What happens if people start translating in multiple languages and the dictionary becoming huge. Let's assume french, chinese, japanese, korean, polish, dutch, ... - this would become pretty big after a while. **Your thoughts?**

_______

This is my first pull request, I would really like to contribute. Feedback is much, much appreciated!

Best regards,
Daniel.