### PR TITLE
fix a copy&paste error on check for movement stop if opposite controls are pressed

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2393,7 +2393,7 @@ this.setYaw = function(yaw, animated, callback, callbackArgs) {
  * @instance
  * @returns {number[]} [yaw pitch, maximum yaw]
  */
-this.getYawBounds = function() { // unused
+this.getYawBounds = function() {
     return [config.minYaw, config.maxYaw];
 };
 
@@ -2404,7 +2404,7 @@ this.getYawBounds = function() { // unused
  * @param {number[]} bounds - [minimum yaw, maximum yaw]
  * @returns {Viewer} `this`
  */
-this.setYawBounds = function(bounds) { // unused
+this.setYawBounds = function(bounds) {
     config.minYaw = Math.max(-180, Math.min(bounds[0], 180));
     config.maxYaw = Math.max(-180, Math.min(bounds[1], 180));
     return this;

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1264,7 +1264,7 @@ function keyRepeat() {
     }
     
     // Stop movement if opposite controls are pressed
-    if (keysDown[0] && keysDown[0]) {
+    if (keysDown[0] && keysDown[1]) {
         speed.hfov = 0;
     }
     if ((keysDown[2] || keysDown[6]) && (keysDown[3] || keysDown[7])) {
@@ -2393,7 +2393,7 @@ this.setYaw = function(yaw, animated, callback, callbackArgs) {
  * @instance
  * @returns {number[]} [yaw pitch, maximum yaw]
  */
-this.getYawBounds = function() {
+this.getYawBounds = function() { // unused
     return [config.minYaw, config.maxYaw];
 };
 
@@ -2404,7 +2404,7 @@ this.getYawBounds = function() {
  * @param {number[]} bounds - [minimum yaw, maximum yaw]
  * @returns {Viewer} `this`
  */
-this.setYawBounds = function(bounds) {
+this.setYawBounds = function(bounds) { // unused
     config.minYaw = Math.max(-180, Math.min(bounds[0], 180));
     config.maxYaw = Math.max(-180, Math.min(bounds[1], 180));
     return this;


### PR DESCRIPTION
This is a trivial fix for an apparently minor bug w.r.t. checking elements of `keysDown`.

It also highlights that two functions are unused: `getYawBounds()` and `getYawBounds()`.