### PR TITLE
avoid showing out-of-range areas of partial (cylindrical) panoramas

### DIFF
--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -309,6 +309,14 @@ Specifies an array containing RGB values [0, 1] that sets the background color
 shown past the edges of a partial panorama. Defaults to `[0, 0, 0]` (black).
 Does not work for `cubemap` panoramas.
 
+### `avoidShowingBackground` (boolean)
+
+If set to `true`, prevent displaying out-of-range areas of a partial panorama
+by constraining the yaw and the field-of-view. Even at the corners and edges
+of the canvas only areas actually belonging to the image
+(i.e., within [`minYaw`, `maxYaw`] and [`minPitch`, `maxPitch`]) are shown,
+thus setting the `backgroundColor` option is not needed if this option is set.
+Defaults to `false`.
 
 
 ## `equirectangular` specific options

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -500,6 +500,7 @@ function onImageLoad() {
     }
 
     renderInit();
+    setHfov(config.hfov); // possibly adapt hfov after configuration and canvas is complete; prevents empty space on top or bottom by zomming out too much
     setTimeout(function(){isTimedOut = true;}, 500);
 }
 
@@ -1400,23 +1401,41 @@ function render() {
         // Keep a tmp value of yaw for autoRotate comparison later
         tmpyaw = config.yaw;
 
+        // prevent showing background (empty space) on left or right by adapting min/max yaw
+        var canvas = renderer.getCanvas(),
+            canvasWidth = canvas.width / (window.devicePixelRatio || 1),
+            canvasHeight = canvas.height / (window.devicePixelRatio || 1),
+            hfov2 = config.hfov / 2,
+            vfov2 = Math.atan2(Math.tan(hfov2 / 180 * Math.PI), (canvasWidth / canvasHeight)) * 180 / Math.PI,
+            transposed = config.vaov > config.haov,
+            hoffcut = 0,
+            voffcut = 0;
+        if (transposed) {
+          voffcut = vfov2 * (1 - Math.min(Math.cos((config.pitch - hfov2) / 180 * Math.PI),
+                                          Math.cos((config.pitch + hfov2) / 180 * Math.PI)));
+        } else {
+          hoffcut = hfov2 * (1 - Math.min(Math.cos((config.pitch - vfov2) / 180 * Math.PI),
+                                          Math.cos((config.pitch + vfov2) / 180 * Math.PI)));
+        }
+
         // Ensure the yaw is within min and max allowed
         var yawRange = config.maxYaw - config.minYaw,
             minYaw = -180,
             maxYaw = 180;
         if (yawRange < 360) {
-            minYaw = config.minYaw + config.hfov / 2;
-            maxYaw = config.maxYaw - config.hfov / 2;
+            minYaw = config.minYaw + config.hfov / 2 + hoffcut;
+            maxYaw = config.maxYaw - config.hfov / 2 - hoffcut;
             if (yawRange < config.hfov) {
                 // Lock yaw to average of min and max yaw when both can be seen at once
                 minYaw = maxYaw = (minYaw + maxYaw) / 2;
             }
+            config.yaw = Math.max(minYaw, Math.min(maxYaw, config.yaw));
         }
-        config.yaw = Math.max(minYaw, Math.min(maxYaw, config.yaw));
         
         // Check if we autoRotate in a limited by min and max yaw
         // If so reverse direction
-        if (config.autoRotate !== false && tmpyaw != config.yaw) {
+        if (config.autoRotate !== false && tmpyaw != config.yaw &&
+            prevTime !== undefined) { // this condition prevents changing the direction initially
             config.autoRotate *= -1;
         }
 
@@ -2117,13 +2136,23 @@ function constrainHfov(hfov) {
         // Don't change view if bounds don't make sense
         console.log('HFOV bounds do not make sense (minHfov > maxHfov).')
         return config.hfov;
-    } if (hfov < minHfov) {
-        return minHfov;
-    } else if (hfov > config.maxHfov) {
-        return config.maxHfov;
-    } else {
-        return hfov;
     }
+    var newHfov = config.hfov;
+    if (hfov < minHfov) {
+        newHfov = minHfov;
+    } else if (hfov > config.maxHfov) {
+        nwHfov = config.maxHfov;
+    } else {
+        newHfov = hfov;
+    }
+    if (renderer) {
+        // prevent showing background (empty space) on top or bottom by adapting newHfov
+        newHfov = Math.min(newHfov,
+                           Math.atan(Math.tan((config.maxPitch - config.minPitch) / 360 * Math.PI) /
+                                     renderer.getCanvas().height * renderer.getCanvas().width)
+                               * 360 / Math.PI);
+    }
+    return newHfov;
 }
 
 /**


### PR DESCRIPTION
By adapting yaw and horizontal FOV,
out-of-range areas (i.e, outside [minYaw, maxYaw] or [minPitch, maxPitch]) of partial panoramas are never shown.
