### PR TITLE
support also partial cubemap/fallback images: backgroundColor for missing face(s)

### DIFF
--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -306,8 +306,10 @@ standard keys that are used by the viewer.
 ### `backgroundColor` ([number, number, number])
 
 Specifies an array containing RGB values [0, 1] that sets the background color
-shown past the edges of a partial panorama. Defaults to `[0, 0, 0]` (black).
-Does not work for `cubemap` panoramas.
+for areas where no image data is available. Defaults to `[0, 0, 0]` (black).
+For partial `equirectangular` panoramas this applies to areas past the edges of
+the defined rectangle. For `multires` and `cubemap` (including fallback) panoramas
+this applies to areas corresponding to missing tiles or faces.
 
 ### `avoidShowingBackground` (boolean)
 

--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -361,8 +361,7 @@ said data will override any existing settings. Defaults to `false`.
 This is an array of URLs for the six cube faces in the order front, right,
 back, left, up, down. These are relative to `basePath` if it is set, else they
 are relative to the location of `pannellum.htm`. Absolute URLs can also be
-used.
-
+used. Partial cubemap images may be specified by giving `null` instead of a URL.
 
 
 ## `multires` specific options

--- a/src/js/libpannellum.js
+++ b/src/js/libpannellum.js
@@ -102,11 +102,11 @@ function Renderer(container) {
 
         var s;
         var faceMissing = false;
-        var cubeImgWidth = undefined;
+        var cubeImgWidth;
         if (imageType == 'cubemap') {
             for (s = 0; s < 6; s++) {
                 if (image[s].width > 0) {
-                    if (cubeImgWidth == undefined)
+                    if (cubeImgWidth === undefined)
                         cubeImgWidth = image[s].width;
                     if (cubeImgWidth != image[s].width)
                         console.log('Cube faces have inconsistent widths: ' + cubeImgWidth + ' vs. ' + image[s].width);
@@ -242,7 +242,7 @@ function Renderer(container) {
             };
             var incLoaded = function() {
                 if (this.width > 0) {
-                    if (fallbackImgSize == undefined)
+                    if (fallbackImgSize === undefined)
                         fallbackImgSize = this.width;
                     if (fallbackImgSize != this.width)
                         console.log('Fallback faces have inconsistent widths: ' + fallbackImgSize + ' vs. ' + this.width);

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -350,6 +350,11 @@ function init() {
         };
         
         var onError = function(e) {
+            if (1) { // support partial cubemap image, i.e., missing faces
+                console.log(config.strings.fileAccessError.replace('%s', e.target.src)+'; will use background instead');
+                onLoad();
+                return;
+            }
             var a = document.createElement('a');
             a.href = e.target.src;
             a.innerHTML = a.href;

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -350,11 +350,6 @@ function init() {
         };
         
         var onError = function(e) {
-            if (1) { // support partial cubemap image, i.e., missing faces
-                console.log(config.strings.fileAccessError.replace('%s', e.target.src)+'; will use background instead');
-                onLoad();
-                return;
-            }
             var a = document.createElement('a');
             a.href = e.target.src;
             a.innerHTML = a.href;
@@ -362,13 +357,18 @@ function init() {
         };
         
         for (i = 0; i < panoImage.length; i++) {
-            panoImage[i].onload = onLoad;
-            panoImage[i].onerror = onError;
             p = config.cubeMap[i];
-            if (config.basePath && !absoluteURL(p)) {
-                p = config.basePath + p;
+            if (p == "null") { // support partial cubemap image with explicitly empty faces
+                console.log('Will use background instead of missing cubemap face ' + i);
+                onLoad();
+            } else {
+                if (config.basePath && !absoluteURL(p)) {
+                    p = config.basePath + p;
+                }
+                panoImage[i].onload = onLoad;
+                panoImage[i].onerror = onError;
+                panoImage[i].src = encodeURI(p);
             }
-            panoImage[i].src = encodeURI(p);
         }
     } else if (config.type == 'multires') {
         onImageLoad();

--- a/utils/multires/generate.py
+++ b/utils/multires/generate.py
@@ -32,6 +32,7 @@ from PIL import Image
 import os
 import sys
 import math
+import ast
 from distutils.spawn import find_executable
 import subprocess
 
@@ -123,7 +124,7 @@ origFilename = os.path.join(os.getcwd(), args.inputFile)
 extension = '.jpg'
 if args.png:
     extension = '.png'
-colorList = eval(args.backgroundColor)
+colorList = ast.literal_eval(args.backgroundColor)
 colorTuple = (int(colorList[0]*255), int(colorList[1]*255), int(colorList[2]*255))
 
 if args.debug:

--- a/utils/multires/generate.py
+++ b/utils/multires/generate.py
@@ -90,8 +90,10 @@ args = parser.parse_args()
 # Create output directory
 if os.path.exists(args.output):
     print('Output directory "' + args.output + '" already exists')
-    sys.exit(1)
-os.makedirs(args.output)
+    if not args.debug:
+        sys.exit(1)
+else:
+    os.makedirs(args.output)
 
 # Process input image information
 print('Processing input image information...')

--- a/utils/multires/generate.py
+++ b/utils/multires/generate.py
@@ -4,6 +4,7 @@
 # and nona (from Hugin)
 
 # generate.py - A multires tile set generator for Pannellum
+# Extensions to cylindrical input and partial panoramas by David von Oheimb
 # Copyright (c) 2014-2018 Matthew Petroff
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -42,16 +43,36 @@ except KeyError:
     nona = None
 
 # Parse input
-parser = argparse.ArgumentParser(description='Generate a Pannellum multires tile set from an full equirectangular panorama.',
+parser = argparse.ArgumentParser(description='Generate a Pannellum multires tile set from a full or partial equirectangular or cylindrical panorama.',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('inputFile', metavar='INPUT',
-                    help='full equirectangular panorama to be processed')
+                    help='panorama to be processed')
+parser.add_argument('-C', '--cylindrical', action='store_true',
+                    help='input projection is cylindrical (default is equirectangular)')
+parser.add_argument('-H', '--haov', dest='haov', default=-1, type=float,
+                    help='horizonal angle of view (defaults to 360.0 for full panorama)')
+parser.add_argument('-F', '--hfov', dest='hfov', default=100.0, type=float,
+                    help='starting horizonal field of view (defaults to 100.0)')
+parser.add_argument('-V', '--vaov', dest='vaov', default=-1, type=float,
+                    help='vertical angle of view (defaults to 180.0 for full panorama)') 
+parser.add_argument('-O', '--voffset', dest='vOffset', default=0.0, type=float,
+                    help='starting pitch position (defaults to 0.0)')
+parser.add_argument('-e', '--horizon', dest='horizon', default=0.0, type=int,
+                    help='offset of the horizon in pixels (negative if above middle, defaults to 0)')
 parser.add_argument('-o', '--output', dest='output', default='./output',
-                    help='output directory')
+                    help='output directory, optionally to be used as basePath (defaults to "./output")')
 parser.add_argument('-s', '--tilesize', dest='tileSize', default=512, type=int,
                     help='tile size in pixels')
+parser.add_argument('-f', '--fallbacksize', dest='fallbackSize', default=1024, type=int,
+                    help='fallback tile size in pixels (defaults to 1024)')
 parser.add_argument('-c', '--cubesize', dest='cubeSize', default=0, type=int,
                     help='cube size in pixels, or 0 to retain all details')
+parser.add_argument('-b', '--backgroundcolor', dest='backgroundColor', default="[0.0, 0.0, 0.0]", type=str,
+                    help='RGB triple of values [0, 1] defining background color shown past the edges of a partial panorama (defaults to "[0.0, 0.0, 0.0]")')
+parser.add_argument('-B', '--avoidbackground', action='store_true',
+                    help='viewer should limit view to avoid showning background, so using --backgroundcolor is not needed')
+parser.add_argument('-a', '--autoload', action='store_true',
+                    help='automatically load panorama in viewer')
 parser.add_argument('-q', '--quality', dest='quality', default=75, type=int,
                     help='output JPEG quality 0-100')
 parser.add_argument('--png', action='store_true',
@@ -59,42 +80,70 @@ parser.add_argument('--png', action='store_true',
 parser.add_argument('-n', '--nona', default=nona, required=nona is None,
                     metavar='EXECUTABLE',
                     help='location of the nona executable to use')
+parser.add_argument('-G', '--gpu', action='store_true',
+                    help='perform image remapping by nona on the GPU')
+parser.add_argument('-d', '--debug', action='store_true',
+                    help='debug mode (print status info and keep intermediate files)')
 args = parser.parse_args()
 
 # Process input image information
 print('Processing input image information...')
 origWidth, origHeight = Image.open(args.inputFile).size
-if float(origWidth) / origHeight != 2:
-    print('Error: the image width is not twice the image height.')
-    print('Input image must be a full, not partial, equirectangular panorama!')
-    sys.exit(1)
+haov = args.haov
+if haov == -1:
+    if args.cylindrical or float(origWidth) / origHeight == 2:
+        print('Assuming --haov 360.0')
+        haov = 360.0
+    else:
+        print('Unless given the --haov option, equirectangular input image must be a full (not partial) panorama!')
+        sys.exit(1)
+vaov = args.vaov
+if vaov == -1:
+    if args.cylindrical or float(origWidth) / origHeight == 2:
+        print('Assuming --vaov 180.0')
+        vaov = 180.0
+    else:
+        print('Unless given the --vaov option, equirectangular input image must be a full (not partial) panorama!')
+        sys.exit(1)
 if args.cubeSize != 0:
     cubeSize = args.cubeSize
 else:
     cubeSize = 8 * int(origWidth / math.pi / 8)
-levels = int(math.ceil(math.log(float(cubeSize) / args.tileSize, 2))) + 1
+tileSize = min(args.tileSize, cubeSize)
+levels = int(math.ceil(math.log(float(cubeSize) / tileSize, 2))) + 1
 origHeight = str(origHeight)
 origWidth = str(origWidth)
 origFilename = os.path.join(os.getcwd(), args.inputFile)
 extension = '.jpg'
 if args.png:
     extension = '.png'
+colorList = eval(args.backgroundColor)
+colorTuple = (int(colorList[0]*255), int(colorList[1]*255), int(colorList[2]*255))
+
+if args.debug:
+    print('maxLevel: '+ str(levels))
+    print('tileResolution: '+ str(tileSize))
+    print('cubeResolution: '+ str(cubeSize))
 
 # Create output directory
-os.makedirs(args.output)
+if not os.path.exists(args.output):
+    os.makedirs(args.output)
 
 # Generate PTO file for nona to generate cube faces
 # Face order: front, back, up, down, left, right
 faceLetters = ['f', 'b', 'u', 'd', 'l', 'r']
+projection = "f1" if args.cylindrical else "f4"
+pitch = 0
 text = []
-text.append('p E0 R0 f0 h' + str(cubeSize) + ' n"TIFF_m" u0 v90 w' + str(cubeSize))
+facestr = 'i a0 b0 c0 d0 e'+ str(args.horizon) +' '+ projection + ' h' + origHeight +' w'+ origWidth +' n"'+ origFilename +'" r0 v' + str(haov)
+text.append('p E0 R0 f0 h' + str(cubeSize) + ' w' + str(cubeSize) + ' n"TIFF_m" u0 v90')
 text.append('m g1 i0 m2 p0.00784314')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y0')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y180')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p-90 r0 v360 w' + origWidth + ' y0')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p90 r0 v360 w' + origWidth + ' y0')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y90')
-text.append('i a0 b0 c0 d0 e0 f4 h' + origHeight + ' n"' + origFilename + '" p0 r0 v360 w' + origWidth + ' y-90')
+text.append(facestr +' p' + str(pitch+ 0) +' y0'  )
+text.append(facestr +' p' + str(pitch+ 0) +' y180')
+text.append(facestr +' p' + str(pitch-90) +' y0'  )
+text.append(facestr +' p' + str(pitch+90) +' y0'  )
+text.append(facestr +' p' + str(pitch+ 0) +' y90' )
+text.append(facestr +' p' + str(pitch+ 0) +' y-90')
 text.append('v')
 text.append('*')
 text = '\n'.join(text)
@@ -103,65 +152,84 @@ with open(os.path.join(args.output, 'cubic.pto'), 'w') as f:
 
 # Create cube faces
 print('Generating cube faces...')
-subprocess.check_call([args.nona, '-o', os.path.join(args.output, 'face'), os.path.join(args.output, 'cubic.pto')])
+subprocess.check_call([args.nona, ('-g' if args.gpu else '-d') , '-o', os.path.join(args.output, 'face'), os.path.join(args.output, 'cubic.pto')])
 faces = ['face0000.tif', 'face0001.tif', 'face0002.tif', 'face0003.tif', 'face0004.tif', 'face0005.tif']
 
 # Generate tiles
 print('Generating tiles...')
 for f in range(0, 6):
     size = cubeSize
-    face = Image.open(os.path.join(args.output, faces[f]))
-    if 'A' in face.mode:
-        if face.mode == 'RGBA':
-            face = face.convert('RGB')
-        elif face.mode == 'LA':
-            face = face.convert('L')
-    for level in range(levels, 0, -1):
-        if not os.path.exists(os.path.join(args.output, str(level))):
-            os.makedirs(os.path.join(args.output, str(level)))
-        tiles = int(math.ceil(float(size) / args.tileSize))
-        if (level < levels):
-            face = face.resize([size, size], Image.ANTIALIAS)
-        for i in range(0, tiles):
-            for j in range(0, tiles):
-                left = j * args.tileSize
-                upper = i * args.tileSize
-                right = min(j * args.tileSize + args.tileSize, size)
-                lower = min(i * args.tileSize + args.tileSize, size)
-                tile = face.crop([left, upper, right, lower])
-                tile.load()
-                tile.save(os.path.join(args.output, str(level), faceLetters[f] + str(i) + '_' + str(j) + extension), quality = args.quality)
-        size = int(size / 2)
+    faceExists = os.path.exists(os.path.join(args.output, faces[f]))
+    if faceExists:
+        face = Image.open(os.path.join(args.output, faces[f]))
+        for level in range(levels, 0, -1):
+            if not os.path.exists(os.path.join(args.output, str(level))):
+                os.makedirs(os.path.join(args.output, str(level)))
+            tiles = int(math.ceil(float(size) / tileSize))
+            if (level < levels):
+                face = face.resize([size, size], Image.ANTIALIAS)
+            for i in range(0, tiles):
+                for j in range(0, tiles):
+                    left = j * tileSize
+                    upper = i * tileSize
+                    right = min(j * args.tileSize + args.tileSize, size) # min(...) not really needed
+                    lower = min(i * args.tileSize + args.tileSize, size) # min(...) not really needed
+                    tile = face.crop([left, upper, right, lower])
+                    if args.debug:
+                        print('level: '+ str(level) + ' tiles: '+ str(tiles) + ' tileSize: '+ str(tileSize) + 'size: '+ str(size))
+                        print('left: '+ str(left) + ' upper: '+ str(upper) + ' right: '+ str(right) + ' lower: '+ str(lower))
+                    if (tile.getcolors(1) == None): # more than just one color (the background), i.e., non-empty tile
+                        tile.load()
+                        if tile.mode in ('RGBA', 'LA'):
+                            background = Image.new(tile.mode[:-1], tile.size, colorTuple)
+                            background.paste(tile, tile.split()[-1])
+                            tile = background
+                        tile.save(os.path.join(args.output, str(level), faceLetters[f] + str(i) + '_' + str(j) + extension), quality = args.quality)
+            size = int(size / 2)
 
 # Generate fallback tiles
 print('Generating fallback tiles...')
 for f in range(0, 6):
     if not os.path.exists(os.path.join(args.output, 'fallback')):
         os.makedirs(os.path.join(args.output, 'fallback'))
-    face = Image.open(os.path.join(args.output, faces[f]))
-    if 'A' in face.mode:
-        if face.mode == 'RGBA':
-            face = face.convert('RGB')
-        elif face.mode == 'LA':
-            face = face.convert('L')
-    face = face.resize([1024, 1024], Image.ANTIALIAS)
-    face.save(os.path.join(args.output, 'fallback', faceLetters[f] + extension), quality = args.quality)
+    if os.path.exists(os.path.join(args.output, faces[f])):
+        face = Image.open(os.path.join(args.output, faces[f]))
+        if face.mode in ('RGBA', 'LA'):
+            background = Image.new(face.mode[:-1], face.size, colorTuple)
+            background.paste(face, face.split()[-1])
+            face = background
+        face = face.resize([args.fallbackSize, args.fallbackSize], Image.ANTIALIAS)
+        face.save(os.path.join(args.output, 'fallback', faceLetters[f] + extension), quality = args.quality)
 
 # Clean up temporary files
-os.remove(os.path.join(args.output, 'cubic.pto'))
-for face in faces:
-    os.remove(os.path.join(args.output, face))
+if not args.debug:
+    os.remove(os.path.join(args.output, 'cubic.pto'))
+    for face in faces:
+        if os.path.exists(os.path.join(args.output, face)):
+            os.remove(os.path.join(args.output, face))
 
 # Generate config file
 text = []
 text.append('{')
+text.append('    "haov": ' + str(haov)+ ',')
+text.append('    "hfov": ' + str(args.hfov)+ ',')
+text.append('    "minYaw": ' + str(-haov/2+0)+ ',')
+text.append('       "yaw": ' + str(-haov/2+args.hfov/2)+ ',')
+text.append('    "maxYaw": ' + str(+haov/2+0)+ ',')
+text.append('    "vaov": '    + str(vaov)+ ',')
+text.append('    "vOffset": ' + str(args.vOffset)+ ',')
+text.append('    "minPitch": ' + str(-vaov/2+args.vOffset)+ ',')
+text.append('       "pitch": ' + str(        args.vOffset)+ ',')
+text.append('    "maxPitch": ' + str(+vaov/2+args.vOffset)+ ',')
+text.append('    "backgroundColor": "' + args.backgroundColor+ '",')
+text.append('    "avoidShowingBackground": ' + ("true" if args.avoidbackground else "false") + ',')
+text.append('    "autoLoad": ' + ("true" if args.autoload else "false") + ',')
 text.append('    "type": "multires",')
-text.append('    ')
 text.append('    "multiRes": {')
 text.append('        "path": "/%l/%s%y_%x",')
 text.append('        "fallbackPath": "/fallback/%s",')
 text.append('        "extension": "' + extension[1:] + '",')
-text.append('        "tileResolution": ' + str(args.tileSize) + ',')
+text.append('        "tileResolution": ' + str(tileSize) + ',')
 text.append('        "maxLevel": ' + str(levels) + ',')
 text.append('        "cubeResolution": ' + str(cubeSize))
 text.append('    }')

--- a/utils/multires/generate.py
+++ b/utils/multires/generate.py
@@ -50,9 +50,9 @@ parser.add_argument('inputFile', metavar='INPUT',
 parser.add_argument('-C', '--cylindrical', action='store_true',
                     help='input projection is cylindrical (default is equirectangular)')
 parser.add_argument('-H', '--haov', dest='haov', default=-1, type=float,
-                    help='horizonal angle of view (defaults to 360.0 for full panorama)')
+                    help='horizontal angle of view (defaults to 360.0 for full panorama)')
 parser.add_argument('-F', '--hfov', dest='hfov', default=100.0, type=float,
-                    help='starting horizonal field of view (defaults to 100.0)')
+                    help='starting horizontal field of view (defaults to 100.0)')
 parser.add_argument('-V', '--vaov', dest='vaov', default=-1, type=float,
                     help='vertical angle of view (defaults to 180.0 for full panorama)') 
 parser.add_argument('-O', '--voffset', dest='vOffset', default=0.0, type=float,
@@ -70,7 +70,7 @@ parser.add_argument('-c', '--cubesize', dest='cubeSize', default=0, type=int,
 parser.add_argument('-b', '--backgroundcolor', dest='backgroundColor', default="[0.0, 0.0, 0.0]", type=str,
                     help='RGB triple of values [0, 1] defining background color shown past the edges of a partial panorama (defaults to "[0.0, 0.0, 0.0]")')
 parser.add_argument('-B', '--avoidbackground', action='store_true',
-                    help='viewer should limit view to avoid showning background, so using --backgroundcolor is not needed')
+                    help='viewer should limit view to avoid showing background, so using --backgroundcolor is not needed')
 parser.add_argument('-a', '--autoload', action='store_true',
                     help='automatically load panorama in viewer')
 parser.add_argument('-q', '--quality', dest='quality', default=75, type=int,

--- a/utils/multires/generate.py
+++ b/utils/multires/generate.py
@@ -86,6 +86,12 @@ parser.add_argument('-d', '--debug', action='store_true',
                     help='debug mode (print status info and keep intermediate files)')
 args = parser.parse_args()
 
+# Create output directory
+if os.path.exists(args.output):
+    print('Output directory "' + args.output + '" already exists')
+    sys.exit(1)
+os.makedirs(args.output)
+
 # Process input image information
 print('Processing input image information...')
 origWidth, origHeight = Image.open(args.inputFile).size
@@ -124,10 +130,6 @@ if args.debug:
     print('maxLevel: '+ str(levels))
     print('tileResolution: '+ str(tileSize))
     print('cubeResolution: '+ str(cubeSize))
-
-# Create output directory
-if not os.path.exists(args.output):
-    os.makedirs(args.output)
 
 # Generate PTO file for nona to generate cube faces
 # Face order: front, back, up, down, left, right


### PR DESCRIPTION
Similarly to the recently added support for missing tiles in multires panoramas,
this PR adds support for missing faces in cubemap (which includes fallback) panoramas. 
Any areas for which no data is available are shown with the configurable `backgroundColor`.

I updated the documentation of `backgroundColor` accordingly.

This PR also includes a couple of minor improvements of related code.

This is in a sense a continuation of PR #563.