### PR TITLE
Add workaround for cordova FileReader

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -518,6 +518,10 @@ function onImageLoad() {
  */
 function parseGPanoXMP(image) {
     var reader = new FileReader();
+    // Fix cordova-plugin-file compatibility
+    if (window.cordova && reader._realReader) {
+        reader = reader._realReader;
+    }
     reader.addEventListener('loadend', function() {
         var img = reader.result;
 


### PR DESCRIPTION
As mentioned in [several](https://github.com/mpetroff/pannellum/issues/284) [other](https://github.com/ionic-team/ionic-native/issues/505) [places](https://github.com/ionic-team/ionic2-app-base/issues/126), [cordova-plugin-file](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-file/) is [overwriting the FileReader](https://github.com/mpetroff/pannellum/issues/284#issuecomment-260669954) with one that doesn't follow the spec.

This is arguably a problem with `cordova-plugin-file`. But since a fix doesn't seem to be very high on their priority list, maybe adding this temporary workaround for it to `pannellum` would be a good short term solution.