### PR TITLE
Let customize target attribute for URL HotSpots

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1707,7 +1707,7 @@ function createHotSpot(hs) {
     } else if (hs.URL) {
         a = document.createElement('a');
         a.href = sanitizeURL(hs.URL);
-        a.target = '_blank';
+        a.target = hs.target ? hs.target : '_blank';
         renderContainer.appendChild(a);
         div.className += ' pnlm-pointer';
         span.className += ' pnlm-pointer';


### PR DESCRIPTION
Sometimes it is needed to open HotSpot link right in the same frame ("_self") or in a named one.