### PR TITLE
Changed Math.min to Math.max

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2145,7 +2145,7 @@ function constrainHfov(hfov) {
     // Keep field of view within bounds
     var minHfov = config.minHfov;
     if (config.type == 'multires' && renderer) {
-        minHfov = Math.min(minHfov, renderer.getCanvas().width / (config.multiRes.cubeResolution / 90 * 0.9));
+        minHfov = Math.max(minHfov, renderer.getCanvas().width / (config.multiRes.cubeResolution / 90 * 0.9));
     }
     if (minHfov > config.maxHfov) {
         // Don't change view if bounds don't make sense


### PR DESCRIPTION
Using min causes odd errors where you can actually "zoom closer" than your minHfov setting. 

If the calculation for the multi-res minHfov is smaller than the config.minHfov, then you can zoom closer. This can happen when cubeResolution is very large and canvas.width is very small. In my case, my cuberesolution is 6704 and  canvas.width is 1440. My minHfov is 30 but the calculated minHfov is around 21, allowing me to zoom-in more than desired.