### PR TITLE
Customizable attributes for Hotspots

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1708,7 +1708,13 @@ function createHotSpot(hs) {
     } else if (hs.URL) {
         a = document.createElement('a');
         a.href = sanitizeURL(hs.URL);
-        a.target = hs.target ? hs.target : '_blank';
+        if (hs.attributes) {
+            for (var key in hs.attributes) {
+                a.setAttribute(key, hs.attributes[key]);
+            }
+        } else {
+            a.target = '_blank';
+        }
         renderContainer.appendChild(a);
         div.className += ' pnlm-pointer';
         span.className += ' pnlm-pointer';


### PR DESCRIPTION
Sometimes more than just the target attribute needs to be customized on the hotspot. Expansion of ba35ea8

Hotspots now accept an object with a list of attributes to append to the anchor tag.