### PR TITLE
Extending standalone with more parameters

### DIFF
--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -39,8 +39,8 @@ function parseURLParameters() {
             case 'compass':
                 configFromURL[option] = JSON.parse(value);
                 break;
-            case 'author': case 'title': case 'firstScene': case 'fallback':
-            case 'preview': case 'panorama': case 'config':
+            case 'author': case 'authorURL': case 'title': case 'firstScene':
+            case 'fallback': case 'preview': case 'panorama': case 'config':
                 configFromURL[option] = decodeURIComponent(value);
                 break;
             default:

--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -32,9 +32,11 @@ function parseURLParameters() {
             case 'hfov': case 'pitch': case 'yaw': case 'haov': case 'vaov':
             case 'minHfov': case 'maxHfov': case 'minPitch': case 'maxPitch':
             case 'minYaw': case 'maxYaw': case 'vOffset': case 'autoRotate':
+            case 'autoRotateInactivityDelay':
                 configFromURL[option] = Number(value);
                 break;
-            case 'autoLoad': case 'ignoreGPanoXMP':
+            case 'autoLoad': case 'ignoreGPanoXMP': case 'hotSpotDebug':
+            case 'compass':
                 configFromURL[option] = JSON.parse(value);
                 break;
             case 'author': case 'title': case 'firstScene': case 'fallback':

--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -36,7 +36,7 @@ function parseURLParameters() {
                 configFromURL[option] = Number(value);
                 break;
             case 'autoLoad': case 'ignoreGPanoXMP': case 'hotSpotDebug':
-            case 'compass':
+            case 'compass': case 'showZoomCtrl': case 'showControls':
                 configFromURL[option] = JSON.parse(value);
                 break;
             case 'author': case 'authorURL': case 'title': case 'firstScene':

--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -32,7 +32,7 @@ function parseURLParameters() {
             case 'hfov': case 'pitch': case 'yaw': case 'haov': case 'vaov':
             case 'minHfov': case 'maxHfov': case 'minPitch': case 'maxPitch':
             case 'minYaw': case 'maxYaw': case 'vOffset': case 'autoRotate':
-            case 'autoRotateInactivityDelay':
+            case 'autoRotateInactivityDelay': case 'autoRotateStopDelay':
                 configFromURL[option] = Number(value);
                 break;
             case 'autoLoad': case 'ignoreGPanoXMP': case 'hotSpotDebug':


### PR DESCRIPTION
This version of the `standalone.js` supports settings _hotSpotDebug, compass, autoRotateInactivityDelay, autoRotateStopDelay, authorURL, showZoomCtrl and showControls_