### PR TITLE
Return JPEG instead of PNG when passing returnImage option to render

### DIFF
--- a/src/js/libpannellum.js
+++ b/src/js/libpannellum.js
@@ -738,7 +738,7 @@ function Renderer(container) {
         }
         
         if (params.returnImage !== undefined) {
-            return canvas.toDataURL('image/png');
+            return canvas.toDataURL('image/jpeg');
         }
     };
     


### PR DESCRIPTION
Its significantly faster to create a jpeg image than a png. This speeds up the time before transitions between scenes when fades are used.