### PR TITLE
Add scale option to hotspot

### DIFF
--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -318,7 +318,10 @@ for the hot spot's `click` event. The event object and the contents of
 
 #### `scale` (boolean)
 
-When `true`, the hotspot is scaled to match the fish eye effect of the image
+When `true`, the hot spot is scaled to match changes in the field of view,
+relative to the initial field of view. Note that this does not account for
+changes in local image scale that occur due to distortions within the viewport.
+Defaults to `false`.
 
 ### `hotSpotDebug` (boolean)
 

--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -316,6 +316,10 @@ If `clickHandlerFunc` is specified, this function is added as an event handler
 for the hot spot's `click` event. The event object and the contents of
 `clickHandlerArgs` are passed to the function as arguments.
 
+#### `scale` (boolean)
+
+When `true`, the hotspot is scaled to match the fish eye effect of the image
+
 ### `hotSpotDebug` (boolean)
 
 When `true`, the mouse pointer's pitch and yaw are logged to the console when

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1839,6 +1839,9 @@ function renderHotSpot(hs) {
         coord[1] += (canvasHeight - hs.div.offsetHeight) / 2;
         var transform = 'translate(' + coord[0] + 'px, ' + coord[1] +
             'px) translateZ(9999px) rotate(' + config.roll + 'deg)';
+        if (hs.scale) {
+            transform += ' scale(' + (origHfov/config.hfov) / z + ')';
+        }
         hs.div.style.webkitTransform = transform;
         hs.div.style.MozTransform = transform;
         hs.div.style.transform = transform;


### PR DESCRIPTION
When `true`, the hotspot is scaled to match the fish eye effect of the image.

Hotspots then appear to be embedded in the panorama instead of floating on top