### PR TITLE
Adding complete example with Dockerfile to use generate.py

### DIFF
--- a/utils/multires/Dockerfile
+++ b/utils/multires/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:18.04
+
+# docker build -t generate-panorama .
+# docker run -it -v $PWD:/data generate-panorama /data/image.png
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+    apt-get install -y python3 python3-dev software-properties-common && \
+    add-apt-repository ppa:ubuntuhandbook1/apps && \
+    apt-get update && \
+    apt-get install -y hugin
+
+RUN apt-get install -y wget && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    pip3 install Pillow
+
+ADD generate.py /generate.py
+ENTRYPOINT ["python3", "/generate.py"]

--- a/utils/multires/Dockerfile
+++ b/utils/multires/Dockerfile
@@ -1,19 +1,11 @@
 FROM ubuntu:18.04
 
 # docker build -t generate-panorama .
-# docker run -it -v $PWD:/data generate-panorama /data/image.png
+# docker run -it -v $PWD:/data generate-panorama /data/image.jpg
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
-    apt-get install -y python3 python3-dev software-properties-common && \
-    add-apt-repository ppa:ubuntuhandbook1/apps && \
-    apt-get update && \
-    apt-get install -y hugin
-
-RUN apt-get install -y wget && \
-    wget https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py && \
-    pip3 install Pillow
+    apt-get install -y python3 python3-pil hugin-tools
 
 ADD generate.py /generate.py
 ENTRYPOINT ["python3", "/generate.py"]

--- a/utils/multires/README.md
+++ b/utils/multires/README.md
@@ -1,0 +1,73 @@
+# Generate a Panorama
+
+This is a small Dockerfile that will allow you to easily generate a panorama
+with the [generate.py](generate.py), without needing to install dependencies
+on your host.
+
+## Get a Panorama
+If you don't have your own, it's easy to use one of the examples in the repository.
+From this folder:
+
+```bash
+$ cp ../../examples/examplepano.jpg .
+```
+
+Then build the Docker container:
+
+```bash
+$ docker build -t generate-panorama .
+```
+
+When it's finished, you can bind the present working directory to a location in 
+the container (/data) so that your image is found in the container. Notice
+that we also need to specify the output to be in a directory that is bound
+to our host:
+
+```
+$ docker run -it -v $PWD:/data generate-panorama --output /data/output /data/examplepano.jpg
+Processing input image information...
+Assuming --haov 360.0
+Assuming --vaov 180.0
+Generating cube faces...
+Generating tiles...
+Generating fallback tiles...
+```
+
+The final output will be in your present working directory,
+
+```
+$ ls output/
+1  2  3  config.json  fallback
+```
+
+Now let's cd back to the root and start a server:
+
+```bash
+$ cd ../..
+$ python3 -m http.server
+```
+
+Given a config folder in `utils/multires/config` we would want to open the browser to
+
+[http://localhost:8000/src/standalone/pannellum.htm?config=../../utils/multires/output/config.json](http://localhost:8000/src/standalone/pannellum.htm?config=../../utils/multires/output/config.json)
+
+And as you load the panorama, you'll see lots of output in the console! Good job,
+you're done!
+
+```bash
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/standalone/pannellum.htm?config=../../utils/multires/output/config.json HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/css/pannellum.css HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/standalone/standalone.css HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/js/libpannellum.js HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/js/pannellum.js HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/standalone/standalone.js HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /utils/multires/output/config.json HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/css/img/background.svg HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/css/img/sprites.svg HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/css/img/compass.svg HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:26] "GET /src/css/img/grab.svg HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:27] "GET /utils/multires/output//1/r0_0.jpg HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:27] "GET /utils/multires/output//1/f0_0.jpg HTTP/1.1" 200 -
+127.0.0.1 - - [09/Aug/2019 09:41:27] "GET /utils/multires/output//1/u0_0.jpg HTTP/1.1" 200 -
+...
+```

--- a/utils/multires/readme.md
+++ b/utils/multires/readme.md
@@ -1,29 +1,58 @@
-# Generate a Panorama
-
-This is a small Dockerfile that will allow you to easily generate a panorama
-with the [generate.py](generate.py), without needing to install dependencies
-on your host.
+# Generating multi-resolution tiles for a panorama
 
 ## Get a Panorama
 If you don't have your own, it's easy to use one of the examples in the repository.
-From this folder:
+From this directory, run:
 
 ```bash
 $ cp ../../examples/examplepano.jpg .
 ```
 
-Then build the Docker container:
+## Generate tiles
+
+To use the `generate.py` script, either its dependencies need to be installed,
+or [Docker](https://www.docker.com/) can be used to avoid this installation.
+
+### Option 1: with local dependencies
+
+The `generate.py` script depends on `nona` (from [Hugin](http://hugin.sourceforge.net/)),
+as well as Python with the [Pillow](https://pillow.readthedocs.org/) package. On Ubuntu,
+these dependencies can be installed by running:
+
+```bash
+$ sudo apt install python3 python3-pil hugin-tools
+```
+
+Once the dependencies are installed, a tileset can generated with:
+
+```bash
+$ python3 generate.py examplepano.jpg
+Processing input image information...
+Assuming --haov 360.0
+Assuming --vaov 180.0
+Generating cube faces...
+Generating tiles...
+Generating fallback tiles...
+```
+
+
+### Option 2: with Docker
+
+A small Dockerfile is provided that allows one to easily generate a panorama tileset
+with the [generate.py](generate.py) script, without needing to install dependencies
+on one's host.
+
+First, build the Docker container:
 
 ```bash
 $ docker build -t generate-panorama .
 ```
 
 When it's finished, you can bind the present working directory to a location in 
-the container (/data) so that your image is found in the container. Notice
-that we also need to specify the output to be in a directory that is bound
-to our host:
+the container (`/data`) so that your image is found in the container. Notice
+that the output needs to be specified in a directory that is bound to the host:
 
-```
+```bash
 $ docker run -it -v $PWD:/data generate-panorama --output /data/output /data/examplepano.jpg
 Processing input image information...
 Assuming --haov 360.0
@@ -33,26 +62,27 @@ Generating tiles...
 Generating fallback tiles...
 ```
 
-The final output will be in your present working directory,
+## Viewing output (for either method)
 
-```
+The final output will be in your present working directory:
+
+```bash
 $ ls output/
 1  2  3  config.json  fallback
 ```
 
-Now let's cd back to the root and start a server:
+Next, change back to the root and start a server:
 
 ```bash
 $ cd ../..
 $ python3 -m http.server
 ```
 
-Given a config folder in `utils/multires/config` we would want to open the browser to
+A generated tileset and configuration in `utils/multires/output` can then be viewed by navigating a browser to:
 
 [http://localhost:8000/src/standalone/pannellum.htm?config=../../utils/multires/output/config.json](http://localhost:8000/src/standalone/pannellum.htm?config=../../utils/multires/output/config.json)
 
-And as you load the panorama, you'll see lots of output in the console! Good job,
-you're done!
+When the page is loaded, the console will output a logging stream corresponding to the HTTP requests:
 
 ```bash
 127.0.0.1 - - [09/Aug/2019 09:41:24] "GET /src/standalone/pannellum.htm?config=../../utils/multires/output/config.json HTTP/1.1" 200 -
@@ -71,3 +101,5 @@ you're done!
 127.0.0.1 - - [09/Aug/2019 09:41:27] "GET /utils/multires/output//1/u0_0.jpg HTTP/1.1" 200 -
 ...
 ```
+
+The panorama, in multi-resolution format, should display in the browser.


### PR DESCRIPTION
This pull request will provide a simple Dockerfile for the user to build a container with all required dependencies to run generate.py. It's likely that a new user won't have hugin, and perhaps some of the Python packages, and the container will get them up and running much more quickly than figuring out the dependencies. I've also written up a README with full instructions for using generate!

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>