### PR TITLE
Adding missing Dockerfile dependency

### DIFF
--- a/utils/multires/Dockerfile
+++ b/utils/multires/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
-    apt-get install -y python3 python3-pil hugin-tools
+    apt-get install -y python3 python3-dev python3-pil hugin-tools
 
 ADD generate.py /generate.py
 ENTRYPOINT ["python3", "/generate.py"]


### PR DESCRIPTION
Hey @mpetroff - when you edited the Dockerfile, it broke because get-pip.py would install distutils:

```bash
$ docker run -it -v $PWD:/data generate-panorama --output /data/output /data/examplepano.jpg
Traceback (most recent call last):
  File "/generate.py", line 36, in <module>
    from distutils.spawn import find_executable
ModuleNotFoundError: No module named 'distutils.spawn'
```
Since you are keen on using a package manager, I added python-pip instead to resolve the issue (and it's tested) - working as expected!

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>