### PR TITLE
Fix missing DeviceMotionEvent error in Safari (desktop)

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2369,7 +2369,8 @@ function stopOrientation() {
  * @private
  */
 function startOrientation() {
-    if (typeof DeviceMotionEvent.requestPermission === 'function') {
+    if (typeof DeviceMotionEvent === 'function' &&
+        typeof DeviceMotionEvent.requestPermission === 'function') {
         DeviceOrientationEvent.requestPermission().then(function(response) {
             if (response == 'granted') {
                 orientation = 1;


### PR DESCRIPTION
Desktop Safari (at least 11.x) is failing to open Pannellum due to the JS error "Can't find variable: DeviceMotionEvent". This PR fixes above error