### PR TITLE
Add touchend event to make clickHandlerFunc work on touch devices

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -1800,6 +1800,9 @@ function createHotSpot(hs) {
         div.addEventListener('click', function(e) {
             hs.clickHandlerFunc(e, hs.clickHandlerArgs);
         }, 'false');
+        div.addEventListener('touchend', function(e) {
+            hs.clickHandlerFunc(e, hs.clickHandlerArgs);
+        }, 'false');
         div.className += ' pnlm-pointer';
         span.className += ' pnlm-pointer';
     }


### PR DESCRIPTION
Using a click handler in a hotspot with clickHandlerFunc and clickHandlerArgs didn't work on touch devices, adding the touchend event fixes this.