### PR TITLE
startAutoRotate | possible improvement

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2814,7 +2814,7 @@ this.startAutoRotate = function(speed, pitch, hfov) {
     pitch = pitch === undefined ? origPitch : pitch;
     hfov = hfov === undefined ? origHfov : hfov;
     config.autoRotate = speed;
-    _this.lookAt(pitch, undefined, origHfov, 3000);
+    _this.lookAt(pitch, undefined, hfov, 3000);
     animateInit();
     return this;
 };

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2806,11 +2806,13 @@ this.setHorizonPitch = function(pitch) {
  * @instance
  * @param {number} [speed] - Auto rotation speed / direction. If not specified, previous value is used.
  * @param {number} [pitch] - The pitch to rotate at. If not specified, inital pitch is used.
+ * @param {number} [hfov] - The hfov to rotate at. If not specified, inital hfov is used.
  * @returns {Viewer} `this`
  */
-this.startAutoRotate = function(speed, pitch) {
+this.startAutoRotate = function(speed, pitch, hfov) {
     speed = speed || autoRotateSpeed || 1;
     pitch = pitch === undefined ? origPitch : pitch;
+    hfov = hfov === undefined ? origHfov : hfov;
     config.autoRotate = speed;
     _this.lookAt(pitch, undefined, origHfov, 3000);
     animateInit();


### PR DESCRIPTION
`startAutoRotate(speed, pitch, hfov)`

Use case:

1. by using "getPitch()" and "getHfov()" as parameter you can just rotate your panorama with the current view.
2. if origHfov is set to a small value (eg. to start with a highlight inside a big panorama) you still can use startAutoRotate with a wider view