### PR TITLE
add %l0 placeholder for 0 based level numbering in MultiresNode

### DIFF
--- a/src/js/libpannellum.js
+++ b/src/js/libpannellum.js
@@ -885,7 +885,7 @@ function Renderer(container) {
         this.level = level;
         this.x = x;
         this.y = y;
-        this.path = path.replace('%s',side).replace('%l',level).replace('%x',x).replace('%y',y);
+        this.path = path.replace('%s',side).replace('%l0',level-1).replace('%l',level).replace('%x',x).replace('%y',y);
         this.parentPath = parentPath;
     }
 


### PR DESCRIPTION
I'm using an 3rd party tool to produce the tiles for the faces - it offers 4 patterns for file and folder hirarchy/naming but all start at level 0.
This is an easy fix that may come handy for others as well.