### PR TITLE
iphone workaround for fullscreen

### DIFF
--- a/src/css/pannellum.css
+++ b/src/css/pannellum.css
@@ -480,3 +480,14 @@ div.pnlm-tooltip:hover span:after {
 .pnlm-pointer {
     cursor: pointer;
 }
+
+.pnlm-workaroundfullscreen {
+    position: absolute !important ;
+    top: 0; 
+    right: 0; 
+    bottom: 0; 
+    left: 0; 
+    height: 100% !important;
+}
+
+

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -103,6 +103,7 @@ var defaultConfig = {
     showZoomCtrl: true,
     autoLoad: false,
     showControls: true,
+    workaroundFullscreen: true,
     orientationOnByDefault: false,
     hotSpotDebug: false,
     backgroundColor: [0, 0, 0],
@@ -259,7 +260,7 @@ controls.container.appendChild(controls.zoom);
 controls.fullscreen = document.createElement('div');
 controls.fullscreen.addEventListener('click', toggleFullscreen);
 controls.fullscreen.className = 'pnlm-fullscreen-toggle-button pnlm-sprite pnlm-fullscreen-toggle-button-inactive pnlm-controls pnlm-control';
-if (document.fullscreenEnabled || document.mozFullScreenEnabled || document.webkitFullscreenEnabled || document.msFullscreenEnabled)
+if (document.fullscreenEnabled || document.mozFullScreenEnabled || document.webkitFullscreenEnabled || document.msFullscreenEnabled || config.workaroundFullscreen))
     controls.container.appendChild(controls.fullscreen);
 
 // Device orientation toggle
@@ -2266,8 +2267,8 @@ function processOptions(isPreview) {
                 break;
 
             case 'showFullscreenCtrl':
-                if (config[key] && config.showControls != false && ('fullscreen' in document || 'mozFullScreen' in document ||
-                    'webkitIsFullScreen' in document || 'msFullscreenElement' in document)) {
+                if (config[key] && config.showControls != false && (('fullscreen' in document || 'mozFullScreen' in document ||
+                    'webkitIsFullScreen' in document || 'msFullscreenElement' in document) || config.workaroundFullscreen) ) {
                     
                     // Show fullscreen control
                     controls.fullscreen.style.display = 'block';
@@ -2319,6 +2320,13 @@ function processOptions(isPreview) {
  */
 function toggleFullscreen() {
     if (loaded && !error) {
+        
+        if (container.classList.contains("pnlm-workaroundfullscreen")) {
+            container.classList.remove("pnlm-workaroundfullscreen");
+        } else {
+            container.classList.add("pnlm-workaroundfullscreen");
+        }
+        
         if (!fullscreenActive) {
             try {
                 if (container.requestFullscreen) {

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -103,7 +103,7 @@ var defaultConfig = {
     showZoomCtrl: true,
     autoLoad: false,
     showControls: true,
-    workaroundFullscreen: true,
+    workaroundFullscreen: true, //set true if fullscreen api is not supported
     orientationOnByDefault: false,
     hotSpotDebug: false,
     backgroundColor: [0, 0, 0],


### PR DESCRIPTION
this is a workarround for the unsupported fullscreen api on ios (iphones/ipads).
i have added a new config value "workaroundFullscreen" (by default on) which now forces to show the fullscreen button.
on click it maximizes, additionally to the fullscreen api function, the pannellum container class. so if the api is not working, you still get something like a fullscreen inside the browser. on iphones it now looks like a fullscreen.

the config value is not really needed nor really useful. it was just a switch for the workarround to check the difference. i didnt wanted to throw the whole logic upside down. please change this as you see fit.