### PR TITLE
Documentation: Hotspot "`click`" event types

### DIFF
--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -335,7 +335,7 @@ spot tooltip DOM instead of the default function. The contents of
 #### `clickHandlerFunc` (function) and `clickHandlerArgs` (object)
 
 If `clickHandlerFunc` is specified, this function is added as an event handler
-for the hot spot's `click` event. The event object and the contents of
+for the hot spot's `click`, `pointerup` or `touchend` events. The event object and the contents of
 `clickHandlerArgs` are passed to the function as arguments.
 
 #### `draggable`


### PR DESCRIPTION
The [documentation states](https://pannellum.org/documentation/reference/#:~:text=hot%20spot%E2%80%99s%20click%20event) that the hotspot `click` event is handled by the function set in `clickHandlerFunc` field.
However, not only the hotspot `click` event, [but also the `pointerup` and `touchend` events](https://github.com/mpetroff/pannellum/blob/master/src/js/pannellum.js#L1938-L1949) will cause the `clickHandlerFunc` to be called - which makes sense as just the `click` event only works with a mouse input, not with touch (as being usually the sole input method on current mobile devices).

Maybe this should rather be named "hotspot selection" instead of "hotspot click", encompassing all events/interactions that indicate the intend to select that hotspot? But renaming this field would introduce a breaking change, so instead just name it like this in the documentation?