### PR TITLE
Add pannellumloaded event dispatched from standalone.js

### DIFF
--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -10,6 +10,12 @@ function anError(error, showHTML) {
     document.getElementById('container').appendChild(errorMsg);
 }
 
+function dispatchLoaded(configFromURL) {
+    var event = new Event('pannellumloaded');
+    event.configFromURL = configFromURL;
+    document.dispatchEvent(event);
+}
+
 var viewer;
 function parseURLParameters() {
     var URL;
@@ -113,6 +119,7 @@ function parseURLParameters() {
             // Create viewer
             configFromURL.escapeHTML = true;
             viewer = pannellum.viewer('container', configFromURL);
+            dispatchLoaded(configFromURL);
         };
         request.open('GET', configFromURL.config);
         request.send();
@@ -127,6 +134,7 @@ function parseURLParameters() {
     configFromURL.escapeHTML = true;
     configFromURL.targetBlank = true;
     viewer = pannellum.viewer('container', configFromURL);
+    dispatchLoaded(configFromURL);
 }
 
 // Display error if opened from local file


### PR DESCRIPTION
Hi! I'm a first-time contributor.

We are working on a panoramic tour of the International Space Station and wanted to include a custom overview map widget in the upper right corner of the Pannellum display. (You can see a screen shot below; the red arrow in the overview map moves according to which scene is loaded, and rotates as the yaw changes.)

We were able to develop the map widget and use it along with the standalone Pannellum viewer almost unmodified. We just needed a small modification to trigger an event we call `pannellumloaded`, which our code can use to trigger setup of our custom widget in the context of the main Pannellum display.

We're very happy with Pannellum and we can continue using our fork without problems, but we thought others in a similar position might find this event useful.

Thanks for all your effort maintaining Pannellum!

![image](https://user-images.githubusercontent.com/190582/214718810-748985b3-c768-42d1-bfca-513bef0e0a08.png