### PR TITLE
Add "sticky" option to hot spots

### DIFF
--- a/doc/json-config-parameters.md
+++ b/doc/json-config-parameters.md
@@ -358,6 +358,11 @@ changes in local image scale that occur due to distortions within the viewport.
 If set to a number, a fixed scaling is applied relative to the default hot spot
 size. Defaults to `false`.
 
+#### `sticky` (boolean)
+
+When `true`, the hot spot will stick to the edges of the screen, always visible. 
+Defaults to `false`.
+
 ### `hotSpotDebug` (boolean)
 
 When `true`, the mouse pointer's pitch and yaw are logged to the console when

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2081,6 +2081,10 @@ function renderHotSpot(hs) {
         // Apply transform
         coord[0] += (canvasWidth - hs.div.offsetWidth) / 2;
         coord[1] += (canvasHeight - hs.div.offsetHeight) / 2;
+        if (hs.sticky) {
+            coord[0] = Math.min(canvasWidth - hs.div.offsetWidth, Math.max(0, coord[0]));
+            coord[1] = Math.min(canvasHeight - hs.div.offsetHeight, Math.max(0, coord[1]));
+        }
         var transform = 'translate(' + coord[0] + 'px, ' + coord[1] +
             'px) translateZ(9999px) rotate(' + config.roll + 'deg)';
         if (hs.scale) {


### PR DESCRIPTION
A barebones proposal to cover #1193. If hot spot has a new option `sticky` set to truthy value, then hot spot coordinates are clamped to always be within canvas space.

It seems to be working for me and does cover the basic functionality, but I am open to updates if it requires more configuration or logic. E.g. more padding, pointing arrows, not dispatching events unless hot spot should be visible without clamping, maybe some crowding logic so multiple hot spots don't collapse into one in a corner...