### PR TITLE
Pin pyshtools to 4.9.1 in multires generator Dockerfile.

### DIFF
--- a/utils/multires/Dockerfile
+++ b/utils/multires/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-dev python3-numpy python3-pip python3-pil hugin-tools \
  && rm -rf /var/lib/apt/lists/*
-RUN pip3 install pyshtools
+RUN pip3 install pyshtools==4.9.1
 
 ADD generate.py /generate.py
 ENTRYPOINT ["python3", "/generate.py"]


### PR DESCRIPTION
Latest version of pyshtools uses Meson for building and does not build (missing dependencies, bumping ubuntu and adding [listed here](https://shtools.github.io/SHTOOLS/python-installing.html#how-to-install-blas-lapack-and-fftw3) does not help, may be missing something obvious), thus proposing a quick fix to pin version and make it work again.