### PR TITLE
Github actions for Docker image

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/release-container.yml'
+      - 'utils/multires/**'
     tags:
       - "*"
 

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1,0 +1,52 @@
+name: Create and publish a container image on release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: utils/multires
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -47,6 +47,6 @@ jobs:
         with:
           context: utils/multires
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository }}-generate-panorama
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,3 +19,4 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           LOG_LEVEL: debug
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,21 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Renovate
+        uses: renovatebot/github-action@v40.1.11
+        with:
+          configurationFile: renovate.json5
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: debug

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "configMigration": true,
+  "extends": [
+    'config:recommended',
+
+    // Make sure we get a single PR combining all updates
+    'group:all',
+  ],
+  "automerge": false,
+  "separateMinorPatch": true,
+  "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
+  "enabledManagers": [
+    "dockerfile",
+    "custom.regex"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "repology"
+      ],
+      "matchPackagePatterns": [
+        "^debian_"
+      ],
+      "groupName": "debian packages",
+      "groupSlug": "debian"
+    },
+    {
+      "matchDatasources": [
+        "repology"
+      ],
+      "matchPackagePatterns": [
+        "^ubuntu_"
+      ],
+      "groupName": "ubuntu packages",
+      "groupSlug": "ubuntu"
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Update packages set in Dockerfiles",
+      "customType": "regex",
+      "fileMatch": [
+          '(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$',
+          '(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$',
+      ],
+      "matchStrings": [
+        "#\\srenovate:\\sdatasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s(ENV|ARG) .*?_VERSION=\"(?<currentValue>.*)\"\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}",
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}repology{{/if}}"
+    }
+  ],
+
+  // Disable dependency dashboard
+  "dependencyDashboard": false,
+
+  // Use our labelling system
+  "labels": ['dependencies'],
+
+  // We generally always want the major version
+  "separateMajorMinor": false,
+}

--- a/utils/multires/Dockerfile
+++ b/utils/multires/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 # docker build -t generate-panorama .
 # docker run -it -v $PWD:/data generate-panorama /data/image.jpg
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-dev python3-numpy python3-pip python3-pil hugin-tools \
  && rm -rf /var/lib/apt/lists/*
-RUN pip3 install pyshtools==4.9.1
+RUN pip3 install --break-system-packages pyshtools
 
 ADD generate.py /generate.py
 ENTRYPOINT ["python3", "/generate.py"]

--- a/utils/multires/Dockerfile
+++ b/utils/multires/Dockerfile
@@ -1,12 +1,68 @@
+# syntax=docker/dockerfile:1
+
 FROM ubuntu:24.04
 
 # docker build -t generate-panorama .
 # docker run -it -v $PWD:/data generate-panorama /data/image.jpg
 
+# renovate: datasource=repology depName=ubuntu_24_04/python3-defaults versioning=loose
+ARG PYTHON3_VERSION="3.12.3-0ubuntu1"
+
+# renovate: datasource=repology depName=ubuntu_24_04/numpy versioning=loose
+ARG PYTHON3_NUMPY_VERSION="1:1.26.4+ds-6ubuntu1"
+
+# renovate: datasource=repology depName=ubuntu_24_04/python-pip versioning=loose
+ARG PYTHON3_PIP_VERSION="24.0+dfsg-1ubuntu1"
+
+# renovate: datasource=repology depName=ubuntu_24_04/pillow versioning=loose
+ARG PYTHON3_PIL_VERSION="10.2.0-1ubuntu1"
+
+# renovate: datasource=repology depName=ubuntu_24_04/hugin versioning=loose
+ARG HUGIN_VERSION="2023.0.0+dfsg-1build4"
+
+# pyshtools dependencies
+
+# renovate: datasource=repology depName=ubuntu_24_04/python3-astropy versioning=loose
+ARG PYTHON3_ASTROPY_VERSION="6.0.0-1ubuntu2"
+
+# renovate: datasource=repology depName=ubuntu_24_04/python3-matplotlib versioning=loose
+ARG PYTHON3_MATPLOTLIB_VERSION="3.6.3-1ubuntu5"
+
+# renovate: datasource=repology depName=ubuntu_24_04/python3-pooch versioning=loose
+ARG PYTHON3_POOCH_VERSION="1.8.1-1"
+
+# renovate: datasource=repology depName=ubuntu_24_04/requests versioning=loose
+ARG PYTHON3_REQUESTS_VERSION="2.31.0+dfsg-1ubuntu1"
+
+# renovate: datasource=repology depName=ubuntu_24_04/python3-tqdm versioning=loose
+ARG PYTHON3_TQDM_VERSION="4.66.2-2"
+
+# renovate: datasource=repology depName=ubuntu_24_04/python3-xarray versioning=loose
+ARG PYTHON3_XARRAY_VERSION="2024.02.0-2"
+
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-dev python3-numpy python3-pip python3-pil hugin-tools \
- && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+# installation
+        apt-get update; \
+        apt-get full-upgrade -y; \
+        apt-get install -y --no-install-recommends \
+                python3=${PYTHON3_VERSION} \
+                python3-dev=${PYTHON3_VERSION} \
+                python3-numpy=${PYTHON3_NUMPY_VERSION} \
+                python3-pip=${PYTHON3_PIP_VERSION} \
+                python3-pil=${PYTHON3_PIL_VERSION} \
+                hugin-tools=${HUGIN_VERSION} \
+                python3-astropy=${PYTHON3_ASTROPY_VERSION} \
+                python3-matplotlib=${PYTHON3_MATPLOTLIB_VERSION} \
+                python3-pooch=${PYTHON3_POOCH_VERSION} \
+                python3-requests=${PYTHON3_REQUESTS_VERSION} \
+                python3-tqdm=${PYTHON3_TQDM_VERSION} \
+                python3-xarray=${PYTHON3_XARRAY_VERSION} \
+                ; \
+        apt-get remove --purge --auto-remove -y; \
+        rm -rf /var/lib/apt/lists/*;
+
 RUN pip3 install --break-system-packages pyshtools
 
 ADD generate.py /generate.py


### PR DESCRIPTION
This pr do lots of thins:
- Adds a github action to build generate-panorama and push to gh container registry
- Updated the image base to latest (24.04) Ubuntu LTS.
- Add renovate bot to track and upgrade image and ubuntu package versions (this will trigger the action to rebuild image)

For renovatebot you need a PAT token (read only access).