### PR TITLE
Add missing callback invocations to setPitch, setYaw and setHfov.

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2721,6 +2721,8 @@ this.setPitch = function(pitch, animated, callback, callbackArgs) {
             setTimeout(function(){callback(callbackArgs);}, animated);
     } else {
         config.pitch = pitch;
+        if (typeof callback == 'function')
+            callback(callbackArgs);
     }
     animateInit();
     return this;
@@ -2795,6 +2797,8 @@ this.setYaw = function(yaw, animated, callback, callbackArgs) {
             setTimeout(function(){callback(callbackArgs);}, animated);
     } else {
         config.yaw = yaw;
+        if (typeof callback == 'function')
+            callback(callbackArgs);
     }
     animateInit();
     return this;
@@ -2862,6 +2866,8 @@ this.setHfov = function(hfov, animated, callback, callbackArgs) {
             setTimeout(function(){callback(callbackArgs);}, animated);
     } else {
         setHfov(hfov);
+        if (typeof callback == 'function')
+            callback(callbackArgs);
     }
     animateInit();
     return this;


### PR DESCRIPTION
**Issue:**
The methods `setPitch`, `setYaw`, and `setHfov` accept a callback function as an argument, but there are cases where this callback is not invoked. This behavior is unexpected and likely represents a bug.

**Expected Behavior:**
The callback should be invoked consistently whenever the methods are called, regardless of specific conditions.

**Observed Behavior:**
The callback **is invoked** under the following conditions:
1. When the `animate` argument is `true`.
2. When the change in value is smaller than a defined `epsilon`, regardless of the value of `animate`.

The callback **is not invoked** under the following condition:
- When `animate` is `false` **and** the change in value is greater than `epsilon`.

**Impact:**
While the callback is documented to be triggered "when animation finishes", it would be illogical to skip the callback entirely when no animation is requested (`animate = false`). Even without animation, the callback should still be called once the value has been set, as this is essential for proper handling of the method's completion state. The current behavior of skipping the callback in specific non-animated cases is unexpected and likely unintended by design.