### PR TITLE
add support for different panorama in fullscreen

### DIFF
--- a/examples/example-fullscreenPanorama.htm
+++ b/examples/example-fullscreenPanorama.htm
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>pannellum embed example</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body>
+    <iframe width="480" height="390" allowfullscreen style="border-style:none;" src="../src/standalone/pannellum.htm#panorama=../../examples/examplepano-640.jpg&amp;panoramaFullscreen=../../examples/examplepano.jpg&amp;autoLoad=true&amp;showZoomCtrl=false&amp;autoRotate=-1"></iframe>
+</body>
+</html>

--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2327,6 +2327,21 @@ function processOptions(isPreview) {
 function toggleFullscreen() {
     if (loaded && !error) {
         if (!fullscreenActive) {
+            if (config.panoramaFullscreen) {
+                var p = '';
+                if (config.basePath) {
+                    p = config.basePath;
+                }
+                p = absoluteURL(config.panoramaFullscreen) ? config.panoramaFullscreen : p + config.panoramaFullscreen;
+
+                var panoImageFullscreen = document.createElement('img');
+                panoImageFullscreen.src = p;
+                panoImageFullscreen.onload = function() {
+                    panoImage = panoImageFullscreen;
+                    onImageLoad();
+                }
+            }
+
             try {
                 if (container.requestFullscreen) {
                     container.requestFullscreen();

--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -67,6 +67,7 @@ function parseURLParameters() {
             case 'fallback':
             case 'preview':
             case 'panorama':
+            case 'panoramaFullscreen':
             case 'config':
                 configFromURL[option] = decodeURIComponent(value);
                 break;


### PR DESCRIPTION
Hi,

first, thanks for an excellent panorama viewer :-) On my opensource map browser OsmAPP I use pannellum to display street-view panoramas. See eg https://osmapp.org/50.07749,14.44896

Though, currently pannellum accepts only one equirectangular panorama, which is usually several megabytes to load and user scarcely opens it. My idea is to load smaller `panorama` in standard embedded view, and only switch to `panoramaFullscreen` when changing to the fullscreen mode.

Do you think it could be mergable? Or perhaps is there another solution without modyfing pannellum's code?

Thanks!