### PR TITLE
Update orientationYawOffset on scene change (fixes #419)

### DIFF
--- a/src/js/pannellum.js
+++ b/src/js/pannellum.js
@@ -2554,6 +2554,10 @@ function loadScene(sceneId, targetPitch, targetYaw, targetHfov, fadeDone) {
     if (workingHfov !== undefined) {
         config.hfov = workingHfov;
     }
+    
+    // Trigger recalculation of orientationYawOffset in orientationListener()
+    if (orientation === true) orientation = 10;
+	
     fireEvent('scenechange', sceneId);
     load();
 }


### PR DESCRIPTION
When using device orientation for pointing control and loading a new scene, the new config.yaw was not taken into account. This may cause undesired jumps in viewing direction.

This change triggers recalculation of the orientationYawOffset with the config.yaw of the newly loaded scene.